### PR TITLE
Impl [nuclio] Do not send "x-nuclio-*-namespace" headers

### DIFF
--- a/src/nuclio/common/services/nuclio-event-data.servie.js
+++ b/src/nuclio/common/services/nuclio-event-data.servie.js
@@ -66,7 +66,6 @@
          */
         function getEvents(functionData) {
             var headers = {
-                'x-nuclio-function-event-namespace': functionData.metadata.namespace,
                 'x-nuclio-function-name': functionData.metadata.name
             };
 
@@ -87,7 +86,6 @@
             var headers = {
                 'Content-Type': eventData.spec.attributes.headers['Content-Type'],
                 'x-nuclio-path': eventData.spec.attributes.headers['x-nuclio-path'],
-                'x-nuclio-function-namespace': eventData.metadata.namespace,
                 'x-nuclio-function-name': eventData.metadata.labels['nuclio.io/function-name'],
                 'x-nuclio-invoke-via': 'external-ip'
             };

--- a/src/nuclio/common/services/nuclio-functions-data.service.js
+++ b/src/nuclio/common/services/nuclio-functions-data.service.js
@@ -28,7 +28,6 @@
         function createFunction(functionData, projectName) {
             var headers = {
                 'Content-Type': 'application/json',
-                'x-nuclio-function-namespace': functionData.metadata.namespace,
                 'x-nuclio-project-name': projectName
             };
 
@@ -52,7 +51,6 @@
         function getFunction(functionData, projectName) {
             var headers = {
                 'Content-Type': 'application/json',
-                'x-nuclio-function-namespace': functionData.namespace,
                 'x-nuclio-project-name': projectName
             };
 
@@ -127,7 +125,6 @@
          */
         function getFunctions(namespace, projectName) {
             var headers = {
-                'x-nuclio-function-namespace': namespace,
                 'x-nuclio-project-name': projectName
             };
             var config = {
@@ -149,7 +146,6 @@
         function updateFunction(functionDetails, projectName) {
             var headers = {
                 'Content-Type': 'application/json',
-                'x-nuclio-function-namespace': functionDetails.metadata.namespace,
                 'x-nuclio-project-name': projectName
             };
             var config = {

--- a/src/nuclio/common/services/nuclio-projects-data.service.js
+++ b/src/nuclio/common/services/nuclio-projects-data.service.js
@@ -29,9 +29,7 @@
                 'Content-Type': 'application/json'
             };
             var data = {
-                metadata: {
-                    namespace: project.metadata.namespace
-                },
+                metadata: {},
                 spec: project.spec
             };
 
@@ -78,15 +76,10 @@
          * @returns {Promise}
          */
         function getProjects() {
-            var headers = {
-                'x-nuclio-project-namespace': 'nuclio'
-            };
-
             return NuclioClientService.makeRequest(
                 {
                     method: 'GET',
                     url: NuclioClientService.buildUrlWithPath('projects', ''),
-                    headers: headers,
                     withCredentials: false
                 })
                 .then(function (response) {
@@ -100,15 +93,10 @@
          * @returns {Promise}
          */
         function getProject(id) {
-            var headers = {
-                'x-nuclio-project-namespace': 'nuclio'
-            };
-
             return NuclioClientService.makeRequest(
                 {
                     method: 'GET',
                     url: NuclioClientService.buildUrlWithPath('projects/', id),
-                    headers: headers,
                     withCredentials: false
                 })
                 .then(function (response) {

--- a/src/nuclio/projects/new-project-dialog/new-project-dialog.component.js
+++ b/src/nuclio/projects/new-project-dialog/new-project-dialog.component.js
@@ -10,8 +10,8 @@
             controller: IgzNewProjectDialogController
         });
 
-    function IgzNewProjectDialogController($scope, lodash, moment, DialogsService, EventHelperService, FormValidationService,
-                                           NuclioProjectsDataService) {
+    function IgzNewProjectDialogController($scope, lodash, moment, DialogsService, EventHelperService,
+                                           FormValidationService, NuclioProjectsDataService) {
         var ctrl = this;
 
         ctrl.data = {};
@@ -73,13 +73,13 @@
                             var status = lodash.get(error, 'data.errors[0].status');
 
                             ctrl.serverError =
-                                status === 400                   ? 'Missing mandatory fields'                         :
+                                status === 400                   ? 'Missing mandatory fields'                           :
                                 status === 403                   ? 'You do not have permissions to create new projects' :
                                 status === 405                   ? 'Failed to create a new project. '             +
                                                                    'The maximum number of projects is reached. '  +
                                                                    'An existing project should be deleted first ' +
-                                                                   'before creating a new one.'                       :
-                                lodash.inRange(status, 500, 599) ? 'Server error'                                     :
+                                                                   'before creating a new one.'                         :
+                                lodash.inRange(status, 500, 599) ? 'Server error'                                       :
                                                                    'Unknown error occurred. Retry later';
 
                             DialogsService.alert(ctrl.serverError);
@@ -128,9 +128,7 @@
          */
         function getBlankData() {
             return {
-                metadata: {
-                    namespace: 'nuclio'
-                },
+                metadata: {},
                 spec: {
                     displayName: '',
                     description: ''

--- a/src/nuclio/projects/project/functions/create-function/function-from-scratch/function-from-scratch.component.js
+++ b/src/nuclio/projects/project/functions/create-function/function-from-scratch/function-from-scratch.component.js
@@ -69,7 +69,11 @@
             if (ctrl.functionFromScratchForm.$valid) {
                 ctrl.toggleSplashScreen({value: true});
 
-                lodash.set(ctrl, 'functionData.metadata.namespace', ctrl.project.metadata.namespace);
+                lodash.defaultsDeep(ctrl, {
+                    functionData: {
+                        metadata: {}
+                    }
+                });
 
                 $state.go('app.project.function.edit.code', {
                     isNewFunction: true,

--- a/src/nuclio/projects/project/functions/create-function/function-from-template/function-from-template.component.js
+++ b/src/nuclio/projects/project/functions/create-function/function-from-template/function-from-template.component.js
@@ -76,8 +76,7 @@
                 ctrl.toggleSplashScreen({value: true});
 
                 lodash.assign(ctrl.functionData.metadata, {
-                    name: ctrl.functionName,
-                    namespace: ctrl.project.metadata.namespace
+                    name: ctrl.functionName
                 });
 
                 $state.go('app.project.function.edit.code', {
@@ -157,8 +156,7 @@
                     ctrl.functionData = angular.copy(selectedTemplate);
 
                     lodash.assign(ctrl.functionData.metadata, {
-                        name: ctrl.functionName,
-                        namespace: ''
+                        name: ctrl.functionName
                     });
                 })
                 .catch(function () {

--- a/src/nuclio/projects/project/functions/create-function/function-import/function-import.component.js
+++ b/src/nuclio/projects/project/functions/create-function/function-import/function-import.component.js
@@ -69,7 +69,9 @@
             if (isYamlFile(file.name)) {
                 ctrl.toggleSplashScreen({value: true});
 
-                lodash.set(importedFunction, 'metadata.namespace', ctrl.project.metadata.namespace);
+                lodash.defaults(importedFunction, {
+                    metadata: {}
+                });
 
                 $state.go('app.project.function.edit.code', {
                     isNewFunction: true,


### PR DESCRIPTION
Also, do not populate `metadata.namespace` with 'nuclio' on frontend for project, function and function event. Send an empty object for `metadata` if it used to have no other property than `namespace`.