### PR TITLE
IG-1868 [Nuclio] Configuration issues

### DIFF
--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.less
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.less
@@ -28,7 +28,6 @@
                 resize: none;
                 white-space: pre;
                 overflow-x: auto;
-                font-family: "Source Code Pro", "Courier New";
             }
         }
     }

--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
@@ -46,7 +46,8 @@
                                             class="nuclio-validating-input build-command-field">
                 </igz-validating-input-field>
             </div>
-            <div class="igz-col-100 build-field">
+            <div class="igz-col-100 build-field"
+                 data-ng-if="$ctrl.version.spec.runtime === 'java'">
                 <div class="field-label">Dependencies</div>
                 <igz-validating-input-field data-field-type="textarea"
                                             data-input-name="dependencies"

--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-runtime-attributes/version-configuration-runtime-attributes.component.js
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-runtime-attributes/version-configuration-runtime-attributes.component.js
@@ -17,6 +17,8 @@
         ctrl.$onInit = onInit;
         ctrl.inputValueCallback = inputValueCallback;
 
+        ctrl.runtimeAttributes = {};
+
         //
         // Hook method
         //
@@ -25,9 +27,9 @@
          * Initialization method
          */
         function onInit() {
-            ctrl.runtimeAttributes = lodash.get(ctrl.version, 'spec.build.runtimeAttributes', []);
+            lodash.set(ctrl.runtimeAttributes, 'repositories', lodash.get(ctrl.version, 'spec.build.runtimeAttributes.repositories', []));
 
-            ctrl.runtimeAttributes = ctrl.runtimeAttributes.join('\n');
+            ctrl.runtimeAttributes.repositories = ctrl.runtimeAttributes.repositories.join('\n');
         }
 
         //
@@ -40,9 +42,9 @@
          * @param {string} field
          */
         function inputValueCallback(newData, field) {
-            if (field === 'attributes') {
-                ctrl.runtimeAttributes = newData;
-                ctrl.version.spec.build.runtimeAttributes = newData.replace(/\r/g, '\n').split(/\n+/);
+            if (field === 'repositories') {
+                ctrl.runtimeAttributes.repositories = newData;
+                lodash.set(ctrl.version, 'spec.build.runtimeAttributes.repositories', newData.replace(/\r/g, '\n').split(/\n+/));
             } else {
                 lodash.set(ctrl.version, field, newData);
             }

--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-runtime-attributes/version-configuration-runtime-attributes.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-runtime-attributes/version-configuration-runtime-attributes.tpl.html
@@ -2,7 +2,8 @@
     <div class="title">Runtime Attributes</div>
     <form name="$ctrl.runtimeAttributesForm" class="runtime-attributes-wrapper">
         <div class="row"
-             data-ng-class="{'info-row': $ctrl.version.spec.runtime !== 'shell'}">
+             data-ng-class="{'info-row': $ctrl.version.spec.runtime !== 'shell'}"
+             data-ng-if="$ctrl.version.spec.runtime !== 'java'">
             <div class="runtime-title">
                 <span class="label">Runtime</span>
                 <div class="runtime">
@@ -26,13 +27,13 @@
              data-ng-if="$ctrl.version.spec.runtime === 'java'">
             <span class="field-label">Repositories</span>
             <igz-validating-input-field data-field-type="textarea"
-                                        data-input-name="attributes"
-                                        data-input-value="$ctrl.runtimeAttributes"
+                                        data-input-name="repositories"
+                                        data-input-value="$ctrl.runtimeAttributes.repositories"
                                         data-is-focused="false"
                                         data-form-object="$ctrl.runtimeAttributesForm"
                                         data-placeholder-text="Type ..."
                                         data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                        data-update-data-field="attributes"
+                                        data-update-data-field="repositories"
                                         class="nuclio-validating-input build-command-field">
             </igz-validating-input-field>
         </div>


### PR DESCRIPTION
- Dependencies in configuration tab should only be display for Java
- Runtime attributes should not display "Runtime" read-only field
- Revert to regular font in "Build Commands" and "Dependencies"
- Runtime Attributes improperly encoded should be bound to `build.runtimeAttributes.repositories` (missing `repositories` leaf)