### PR TITLE
IG-1897 [Nuclio] Move the "Theme" drop-down on Code tab in demo mode

### DIFF
--- a/src/nuclio/projects/project/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.component.js
@@ -10,7 +10,7 @@
             controller: NclVersionCodeController
         });
 
-    function NclVersionCodeController($element, $rootScope, $stateParams, $timeout, lodash, DialogsService,
+    function NclVersionCodeController($element, $rootScope, $stateParams, $timeout, lodash, ConfigService, DialogsService,
                                       PreventDropdownCutOffService, VersionHelperService) {
         var ctrl = this;
 
@@ -62,11 +62,12 @@
         ctrl.$onInit = onInit;
         ctrl.$postLink = postLink;
 
+        ctrl.isDemoMode = ConfigService.isDemoMode;
+        ctrl.inputValueCallback = inputValueCallback;
+        ctrl.onChangeSourceCode = onChangeSourceCode;
         ctrl.selectEntryTypeValue = selectEntryTypeValue;
         ctrl.selectRuntimeValue = selectRuntimeValue;
         ctrl.selectThemeValue = selectThemeValue;
-        ctrl.inputValueCallback = inputValueCallback;
-        ctrl.onChangeSourceCode = onChangeSourceCode;
 
         /**
          * Initialization method

--- a/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
@@ -39,7 +39,7 @@
                             </button>
                         </div>
                         <div class="code-entry-col code-entry-theme-col"
-                             data-ng-if="$ctrl.selectedEntryType.name === 'Edit online'">
+                             data-ng-if="$ctrl.selectedEntryType.name === 'Edit online' && $ctrl.isDemoMode()">
                             <div class="col-label runtime">Theme</div>
                             <igz-default-dropdown data-values-array="$ctrl.themesArray"
                                                   data-item-select-callback="$ctrl.selectThemeValue(item, isItemChanged, field)"


### PR DESCRIPTION
It is currently impossible to have different themes for different instances of monaco editor (see https://github.com/Microsoft/monaco-editor/issues/338).
So for now the "Theme" drop-down field will be in demo mode only.