### PR TITLE
Fix [Nuclio] Wrong API calls/parsing

### DIFF
--- a/src/nuclio/projects/project/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/projects/project/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -70,7 +70,8 @@
 
             ctrl.convertedStatusState = lodash.chain(ctrl.function.status.state).lowerCase().upperFirst().value();
 
-            ctrl.invocationURL = lodash.isNil(ctrl.function.status.httpPort) ? 'Not yet deployed' : 'http://' + ctrl.externalAddress + ':' + ctrl.function.status.httpPort;
+            ctrl.invocationURL = lodash.isNil(ctrl.externalAddress) || lodash.isNil(ctrl.function.status.httpPort) ?
+                'Not yet deployed' : 'http://' + ctrl.externalAddress + ':' + ctrl.function.status.httpPort;
 
             ctrl.actions = initActions();
         }

--- a/src/nuclio/projects/project/functions/functions.component.js
+++ b/src/nuclio/projects/project/functions/functions.component.js
@@ -119,7 +119,7 @@
 
                 ctrl.getExternalIpAddresses()
                     .then(function (response) {
-                        ctrl.externalIPAddress = response.data.externalIPAddresses.addresses[0];
+                        ctrl.externalIPAddress = response.externalIPAddresses.addresses[0];
                     })
                     .catch(function (error) {
                         ctrl.isSplashShowed.value = false;

--- a/src/nuclio/projects/project/functions/version/version.component.js
+++ b/src/nuclio/projects/project/functions/version/version.component.js
@@ -137,7 +137,7 @@
                 ctrl.project = response.project;
 
                 // sets function events data
-                convertTestEventsData(response.events.data);
+                convertTestEventsData(response.events);
 
                 // breadcrumbs config
                 var title = {
@@ -183,7 +183,7 @@
             ctrl.getExternalIpAddresses()
                 .then(function (address) {
                     ctrl.version.ui.invocationURL = lodash.has(ctrl.version, 'status.httpPort') ?
-                        'http://' + address.data.externalIPAddresses.addresses[0] + ':' + ctrl.version.status.httpPort : '';
+                        'http://' + address.externalIPAddresses.addresses[0] + ':' + ctrl.version.status.httpPort : '';
                 })
                 .catch(function (error) {
                     var msg = 'Oops: Unknown error occurred while retrieving external IP address\'';
@@ -292,7 +292,7 @@
                         // update test events list
                         ctrl.getFunctionEvents({functionData: ctrl.version})
                             .then(function (response) {
-                                convertTestEventsData(response.data);
+                                convertTestEventsData(response);
 
                                 if (!lodash.isNil(data.value.selectedEvent)) {
                                     setEventAsSelected(data.value.selectedEvent.spec.displayName);
@@ -355,8 +355,8 @@
          */
         function getDeployStatusState(state) {
             return state === 'ready'    ? 'Successfully deployed' :
-                state === 'error'    ? 'Failed to deploy'      :
-                    'Deploying...'          ;
+                   state === 'error'    ? 'Failed to deploy'      :
+                             'Deploying...'          ;
         }
 
         /**
@@ -399,24 +399,16 @@
                         return $q.reject(response);
                     })
                     .catch(function (invocationData) {
-                        if (invocationData.config.headers['Content-Type'] === 'application/json' && lodash.isObject(invocationData.data)) {
+                        if (invocationData.headers['Content-Type'] === 'application/json' && lodash.isObject(invocationData.body)) {
                             eventContentType = 'json';
-                            invocationData.data = angular.toJson(angular.fromJson(invocationData.data), ' ', 4);
-                        } else if (lodash.startsWith(invocationData.config.headers['Content-Type'], 'image/')) {
+                            invocationData.body = angular.toJson(angular.fromJson(invocationData.body), ' ', 4);
+                        } else if (lodash.startsWith(invocationData.headers['Content-Type'], 'image/')) {
                             eventContentType = 'image';
                         }
 
-                        ctrl.testResult = {
-                            status: {
-                                state: invocationData.xhrStatus,
-                                statusCode: invocationData.status,
-                                statusText: invocationData.statusText
-                            },
-                            headers: invocationData.config.headers,
-                            body: invocationData.data
-                        };
+                        ctrl.testResult = invocationData;
                         ctrl.isDeployResultShown = false;
-                        ctrl.isInvocationSuccess = lodash.startsWith(invocationData.status, '2');
+                        ctrl.isInvocationSuccess = lodash.startsWith(String(invocationData.status), '2');
                         ctrl.isTestResultShown = true;
                     });
 
@@ -575,7 +567,7 @@
 
                             ctrl.getExternalIpAddresses()
                                 .then(function (address) {
-                                    ctrl.version.ui.invocationURL = 'http://' + address.data.externalIPAddresses.addresses[0] + ':' + ctrl.version.status.httpPort;
+                                    ctrl.version.ui.invocationURL = 'http://' + address.externalIPAddresses.addresses[0] + ':' + ctrl.version.status.httpPort;
                                 })
                                 .catch(function (error) {
                                     var msg = 'Oops: Unknown error occurred while retrieving external IP address';

--- a/src/nuclio/projects/project/functions/version/version.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version.tpl.html
@@ -105,7 +105,7 @@
             <span class="result-status-icon"
                   data-ng-class="$ctrl.isInvocationSuccess ? 'igz-icon-tick-round' : 'igz-icon-block'">
             </span>
-                <span class="result-state">Response: {{$ctrl.testResult.status.statusText}}</span>
+                <span class="result-state">Response: {{$ctrl.testResult.statusText}}</span>
             </div>
 
             <div class="ncl-execution-result-block">
@@ -120,7 +120,7 @@
                 <div class="collapsed-block-content-wrapper" data-collapse="$ctrl.rowIsCollapsed.statusCode">
                     <div class="value-row"
                          data-ng-class="{'failed' : !$ctrl.isInvocationSuccess}">
-                        {{$ctrl.testResult.status.statusCode}} {{$ctrl.testResult.status.statusText}}
+                        {{$ctrl.testResult.status}} {{$ctrl.testResult.statusText}}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Remove `ui` and `$$hashKey` properties from project update request
- Shift `created_by` and `created_date` on project update to demo mode
- Fix error handling (assumed Iguazio error JSON-API structure)
- Do not display invocation URL if external IP address not defined
- Do not display an alert message if exernal IP address not fetched
- Omit `spec.loggerSinks` property of function on deploy in non-demo
- Parsing of function invocation response was reworked a bit
- Some general cleanup