### PR TITLE
Code: Add "GitHub" Code Entry Type

### DIFF
--- a/src/nuclio/projects/project/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.component.js
@@ -58,6 +58,11 @@
                 name: 'Archive'
             },
             {
+                id: 'github',
+                visible: true,
+                name: 'GitHub'
+            },
+            {
                 id: 'jar',
                 visible: lodash.get(ctrl.version, 'spec.runtime') === 'java',
                 name: 'Jar'

--- a/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
@@ -103,6 +103,54 @@
                                                 class="nuclio-validating-input">
                     </igz-validating-input-field>
                 </div>
+
+                <div data-ng-if="$ctrl.selectedEntryType.name === 'GitHub'"
+                     class="ncl-code-entry-url">
+                    <div class="field-label">URL</div>
+                    <igz-validating-input-field data-field-type="input"
+                                                data-input-name="githubUrl"
+                                                data-input-value="$ctrl.version.spec.build.path"
+                                                data-is-focused="true"
+                                                data-form-object="$ctrl.versionCodeForm"
+                                                data-validation-is-required="true"
+                                                data-placeholder-text="For example: https://github.com/nuclio/nuclio"
+                                                data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                data-update-data-field="spec.build.path"
+                                                class="nuclio-validating-input">
+                    </igz-validating-input-field>
+                </div>
+
+                <div data-ng-if="$ctrl.selectedEntryType.name === 'GitHub'"
+                     class="ncl-code-entry-url">
+                    <div class="field-label">Branch</div>
+                    <igz-validating-input-field data-field-type="input"
+                                                data-input-name="githubBranch"
+                                                data-input-value="$ctrl.version.spec.build.codeEntryAttributes.branch"
+                                                data-is-focused="false"
+                                                data-form-object="$ctrl.versionCodeForm"
+                                                data-validation-is-required="true"
+                                                data-placeholder-text="For example: master"
+                                                data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                data-update-data-field="spec.build.codeEntryAttributes.branch"
+                                                class="nuclio-validating-input">
+                    </igz-validating-input-field>
+                </div>
+
+                <div data-ng-if="$ctrl.selectedEntryType.name === 'GitHub'"
+                     class="ncl-code-entry-url">
+                    <div class="field-label">Work Dir</div>
+                    <igz-validating-input-field data-field-type="input"
+                                                data-input-name="githubWorkDir"
+                                                data-input-value="$ctrl.version.spec.build.codeEntryAttributes.workDir"
+                                                data-is-focused="false"
+                                                data-form-object="$ctrl.versionCodeForm"
+                                                data-validation-is-required="false"
+                                                data-placeholder-text="For example: /path/to/functions"
+                                                data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                data-update-data-field="spec.build.codeEntryAttributes.workDir"
+                                                class="nuclio-validating-input">
+                    </igz-validating-input-field>
+                </div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
Add a new option to the "Code Entry Type" field:
Label: "GitHub"
Value: `'github'`
Model: `spec.build.codeEntryType` (like it is now, no change)

These are the related fields for this option:

- URL:
Type: text
Default value: empty
Model: `spec.build.path`
Placeholder: "For example: https://github.com/nuclio/nuclio"
Required: yes
- Branch:
Type: text
Default value: empty
Model: `spec.build.codeEntryAttributes.branch`
Placeholder: "For example: master"
Required: yes
- Work Dir:
Type: text
Default value: empty
Model: `spec.build.codeEntryAttributes.workDir`
Placeholder: "For example: /path/to/functions"
Required: no (back-end uses default of "/" in case of empty or undefined `workDir`)

https://trello.com/c/2Da5G6oC