### PR TITLE
Code: Add "Work Dir" to "Archive" code entry type

### DIFF
--- a/src/nuclio/projects/project/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.component.js
@@ -122,9 +122,6 @@
                 lodash.set(ctrl.version, 'spec.build.codeEntryType', ctrl.selectedEntryType.id);
             }
 
-            ctrl.image = lodash.get(ctrl.version, 'spec.image', '');
-            ctrl.archive = lodash.get(ctrl.version, 'spec.build.path', '');
-
             previousEntryType = ctrl.selectedEntryType;
         }
 
@@ -148,7 +145,7 @@
 
             lodash.set(ctrl.version, 'spec.build.codeEntryType', ctrl.selectedEntryType.id);
 
-            if (lodash.includes(['image', 'archive', 'jar'], item.id)) {
+            if (lodash.includes(['image', 'archive', 'github', 'jar'], item.id)) {
                 var functionSourceCode = lodash.get(ctrl.version, 'spec.build.functionSourceCode', '');
                 lodash.merge(ctrl.version, {
                     spec: {
@@ -157,6 +154,9 @@
                         }
                     }
                 });
+
+                lodash.set(ctrl.version, 'spec.build.path', '');
+                lodash.set(ctrl.version, 'spec.build.codeEntryAttributes', {branch: '', workDir: ''});
 
                 if (previousEntryType.id === 'sourceCode') {
                     lodash.set(ctrl.version, 'ui.versionCode', functionSourceCode);

--- a/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
@@ -104,6 +104,22 @@
                     </igz-validating-input-field>
                 </div>
 
+                <div data-ng-if="$ctrl.selectedEntryType.name === 'Archive'"
+                     class="ncl-code-entry-url">
+                    <div class="field-label">Work Dir</div>
+                    <igz-validating-input-field data-field-type="input"
+                                                data-input-name="archiveWorkDir"
+                                                data-input-value="$ctrl.version.spec.build.codeEntryAttributes.workDir"
+                                                data-is-focused="false"
+                                                data-form-object="$ctrl.versionCodeForm"
+                                                data-validation-is-required="false"
+                                                data-placeholder-text="For example: /path/to/functions"
+                                                data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                data-update-data-field="spec.build.codeEntryAttributes.workDir"
+                                                class="nuclio-validating-input">
+                    </igz-validating-input-field>
+                </div>
+
                 <div data-ng-if="$ctrl.selectedEntryType.name === 'GitHub'"
                      class="ncl-code-entry-url">
                     <div class="field-label">URL</div>

--- a/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
@@ -77,7 +77,7 @@
                     <div class="field-label">URL</div>
                     <igz-validating-input-field data-field-type="input"
                                                 data-input-name="image"
-                                                data-input-value="$ctrl.image"
+                                                data-input-value="$ctrl.version.spec.build.path"
                                                 data-is-focused="true"
                                                 data-form-object="$ctrl.versionCodeForm"
                                                 data-validation-is-required="true"
@@ -93,7 +93,7 @@
                     <div class="field-label">URL</div>
                     <igz-validating-input-field data-field-type="input"
                                                 data-input-name="archive"
-                                                data-input-value="$ctrl.archive"
+                                                data-input-value="$ctrl.version.spec.build.path"
                                                 data-is-focused="true"
                                                 data-form-object="$ctrl.versionCodeForm"
                                                 data-validation-is-required="true"


### PR DESCRIPTION
To "Archive" code entry type, add this field:
- Label: "Work Dir"
- Type: text
- Default value: empty
- Model: `spec.build.codeEntryAttributes.workDir`
- Placeholder: "For example: /path/to/functions"
- Required: no (back-end uses default of "/" in case of empty or undefined `workDir`)

https://trello.com/c/oHVHnyf2