### PR TITLE
Fix [Nuclio] Deployment error message not displayed in logger

### DIFF
--- a/src/nuclio/projects/project/functions/functions.component.js
+++ b/src/nuclio/projects/project/functions/functions.component.js
@@ -255,8 +255,8 @@
             ctrl.isSplashShowed.value = true;
 
             ctrl.getFunctions({id: ctrl.project.metadata.name})
-                .then(function (result) {
-                    ctrl.functions = lodash.toArray(lodash.defaultTo(result.data, result));
+                .then(function (functions) {
+                    ctrl.functions = lodash.toArray(functions);
 
                     if (lodash.isEmpty(ctrl.functions) && !$stateParams.createCancelled) {
                         ctrl.isSplashShowed.value = false;

--- a/src/nuclio/projects/project/functions/version/version-code/function-event-pane/function-event-pane.component.js
+++ b/src/nuclio/projects/project/functions/version/version-code/function-event-pane/function-event-pane.component.js
@@ -575,13 +575,13 @@
 
                 // save created event on beck-end
                 ctrl.createFunctionEvent({eventData: eventToSave, isNewEvent: ctrl.createEvent})
-                    .then(function (res) {
+                    .then(function (newEvent) {
                         ctrl.getFunctionEvents({functionData: ctrl.version}).then(function (response) {
                             ctrl.savedEvents = response;
                         });
 
-                        if (ctrl.createEvent && angular.isDefined(res)) {
-                            ctrl.selectedEvent = res.data;
+                        if (ctrl.createEvent && angular.isDefined(newEvent)) {
+                            ctrl.selectedEvent = newEvent;
                             ctrl.selectedEvent.spec.body = lodash.defaultTo(ctrl.selectedEvent.spec.body, '');
                         }
 

--- a/src/nuclio/projects/project/functions/version/version.component.js
+++ b/src/nuclio/projects/project/functions/version/version.component.js
@@ -65,7 +65,7 @@
          * Destructor method
          */
         function onDestroy() {
-           terminateInterval();
+            terminateInterval();
         }
 
         /**
@@ -212,7 +212,7 @@
                     .then(pullFunctionState)
                     .catch(function (error) {
                         var logs = [{
-                            err: error.error
+                            err: error.data.error
                         }];
 
                         lodash.set(ctrl.deployResult, 'status.state', 'error');
@@ -386,7 +386,6 @@
                     })
                     .catch(function (error) {
                         if (error.status !== 404) {
-
                             ctrl.isSplashShowed.value = false;
                         }
                     });


### PR DESCRIPTION
On successful response, Nuclio common components should not assume a `data` property. It should be stripped down for Nuclio by the outer provider.
On failed response, Nuclio common components should assume an entire XHR response object (with `data`, `status`, `hxrStatus`, etc.).