### PR TITLE
Fix [Nuclio] Code entry attributes are falsely sent

### DIFF
--- a/src/iguazio.dashboard-controls.config.js
+++ b/src/iguazio.dashboard-controls.config.js
@@ -1,5 +1,5 @@
 (function () {
-    'use strict'
+    'use strict';
 
     var defaultConfig = {
         url: {

--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -63,6 +63,7 @@
         ctrl.isKafkaTrigger = isKafkaTrigger;
         ctrl.isMQTTTrigger = isMQTTTrigger;
         ctrl.isCronTrigger = isCronTrigger;
+        ctrl.isTriggerType = isTriggerType;
         ctrl.isVolumeType = isVolumeType;
         ctrl.onChangeData = onChangeData;
         ctrl.onSubmitForm = onSubmitForm;
@@ -103,7 +104,7 @@
                 $timeout(validateCronClassValues);
             }
 
-            if (!ctrl.isVolumeType()) {
+            if (ctrl.isTriggerType()) {
                 lodash.defaults(ctrl.item, {
                     workerAllocatorName: ''
                 });
@@ -117,7 +118,7 @@
                 }
             }
 
-            if (!ctrl.isVolumeType() && ctrl.isHttpTrigger()) {
+            if (ctrl.isTriggerType() && ctrl.isHttpTrigger()) {
                 if (lodash.isNil(ctrl.item.workerAvailabilityTimeoutMilliseconds)) {
                     ctrl.item.workerAvailabilityTimeoutMilliseconds = 0;
                 }
@@ -153,7 +154,7 @@
                     .value();
             }
 
-            if (!ctrl.isVolumeType() && ctrl.isKafkaTrigger()) {
+            if (ctrl.isTriggerType() && ctrl.isKafkaTrigger()) {
                 lodash.defaultsDeep(ctrl.item.attributes, {
                     initialOffset: 'latest',
                     sasl: {
@@ -179,14 +180,14 @@
                     .value();
             }
 
-            if (!ctrl.isVolumeType() && isv3ioTrigger()) {
+            if (ctrl.isTriggerType() && isv3ioTrigger()) {
                 lodash.defaults(ctrl.item, {
                     username: '',
                     password: ''
                 });
             }
 
-            if (!ctrl.isVolumeType() && ctrl.isMQTTTrigger()) {
+            if (ctrl.isTriggerType() && ctrl.isMQTTTrigger()) {
                 ctrl.subscriptions = lodash.chain(ctrl.item.attributes.subscriptions)
                     .defaultTo([])
                     .map(function (value, key) {
@@ -203,7 +204,7 @@
                     .value();
             }
 
-            if (!ctrl.isVolumeType() && ctrl.isCronTrigger()) {
+            if (ctrl.isTriggerType() && ctrl.isCronTrigger()) {
                 lodash.defaultsDeep(ctrl.item.attributes, {
                     event: {
                         body: '',
@@ -523,11 +524,18 @@
         }
 
         /**
-         * Checks is input have to be visible for sperific item type
-         * @param {string} name - input name
+         * Returns `true` if item is a trigger.
+         * @returns {boolean} `true` if item is a trigger, or `false` otherwise.
+         */
+        function isTriggerType() {
+            return ctrl.type === 'trigger';
+        }
+
+        /**
+         * Checks is input have to be visible for specific item type
          * @returns {boolean}
          */
-        function isVolumeType(name) {
+        function isVolumeType() {
             return ctrl.type === 'volume';
         }
 

--- a/src/nuclio/common/components/edit-item/edit-item.tpl.html
+++ b/src/nuclio/common/components/edit-item/edit-item.tpl.html
@@ -40,7 +40,7 @@
                  data-ng-if="!$ctrl.isClassSelected()">{{ $ctrl.placeholder }}
             </div>
             <div class="igz-col-45 attribute-field"
-                 data-ng-if="$ctrl.isClassSelected() && !$ctrl.isVolumeType()">
+                 data-ng-if="$ctrl.isClassSelected() && $ctrl.isTriggerType()">
                 <div class="field-label">Worker allocator name</div>
                 <igz-validating-input-field class="nuclio-validating-input"
                                             data-field-type="input"

--- a/src/nuclio/projects/project/functions/functions.service.js
+++ b/src/nuclio/projects/project/functions/functions.service.js
@@ -446,7 +446,7 @@
                     {
                         id: 'hostPath',
                         name: 'Host path'
-                    },
+                    }
                 ]
             };
 
@@ -473,7 +473,7 @@
          * @returns {Object[]} - array of actions
          */
         function initVersionActions() {
-            var actions = [
+            return [
                 {
                     label: 'Edit',
                     id: 'edit',
@@ -493,8 +493,6 @@
                     }
                 }
             ];
-
-            return actions;
         }
     }
 }());

--- a/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-code/version-code.tpl.html
@@ -77,7 +77,7 @@
                     <div class="field-label">URL</div>
                     <igz-validating-input-field data-field-type="input"
                                                 data-input-name="image"
-                                                data-input-value="$ctrl.version.spec.build.path"
+                                                data-input-value="$ctrl.version.spec.image"
                                                 data-is-focused="true"
                                                 data-form-object="$ctrl.versionCodeForm"
                                                 data-validation-is-required="true"


### PR DESCRIPTION
Only properties relevant to the selected "Code Entry Type" should be
sent in the deploy request. (Resolves https://trello.com/c/DFIHMyqY)

Also fix the following:
- `spec.image` is not loaded in "URL" field on function screen init. (relates to PR #298)
- "Worker Allocator Name" is falsely displayed in "Data Bindings". (Resolves https://trello.com/c/nNhy8AbX)