### PR TITLE
Fix [Nuclio] Code: Test pane: fail when response is object

### DIFF
--- a/src/nuclio/projects/project/functions/version/version-code/function-event-pane/function-event-pane.component.js
+++ b/src/nuclio/projects/project/functions/version/version-code/function-event-pane/function-event-pane.component.js
@@ -691,7 +691,12 @@
 
                             var textualFile = lodash.includes(contentType, 'text') || contentType === 'application/json';
 
-                            if (contentType === 'application/json') {
+                            // if content type is "application/json" then attempt to pretty-print JSON. The body could
+                            // be either a serialized-JSON string, or an object.
+                            // monaco editor must be assigned a string, not an object, then even if the content type is
+                            // not "application/json" but for any reason the body is an object, attempt to pretty-print
+                            // it as JSON.
+                            if (contentType === 'application/json' || lodash.isObject(invocationData.body)) {
                                 ctrl.testResult.body = formatJson(invocationData.body);
                             }
 


### PR DESCRIPTION
When response is interpreted as a JS obejct but contet type is not "application/json", there is a breakage in when assigning response body to monaco editor, since monaco editor can receive strings only, and not objects.

Complements PR https://github.com/iguazio/dashboard-controls/pull/392
Relates to PR https://github.com/iguazio/dashboard-controls/pull/382