### PR TITLE
Impl [Nuclio] Function template params: order by `order` property

### DIFF
--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.component.js
@@ -14,17 +14,38 @@
     function NclFunctionFromTemplateDialogController(lodash, EventHelperService) {
         var ctrl = this;
 
+        var FILED_KINDS = ['string', 'number', 'choice'];
+
+        var defaultAttributes = {
+            string: {
+                defaultValue: '',
+                password: false
+            },
+            number: {
+                defaultValue: 0,
+                step: 1,
+                allowZero: false,
+                allowNegative: false,
+                allowDecimal: false
+            },
+            choice: {
+                choices: [],
+                defaultValue: '' // currently assuming "choice" to be a list of strings only
+            }
+        };
         var templateData = {};
 
         ctrl.dropdownOptions = {};
+        ctrl.fields = [];
+        ctrl.templateForm = null;
 
         ctrl.$onInit = onInit;
 
-        ctrl.onApply = onApply;
-        ctrl.onClose = onClose;
+        ctrl.dropdownCallback = dropdownCallback;
         ctrl.inputValueCallback = inputValueCallback;
         ctrl.isFormFilled = isFormFilled;
-        ctrl.dropdownCallback = dropdownCallback;
+        ctrl.onApply = onApply;
+        ctrl.onClose = onClose;
 
         //
         // Hook methods
@@ -34,16 +55,56 @@
          * Initialization method
          */
         function onInit() {
-            lodash.forIn(ctrl.template.values, function (value, key) {
-                var defaultValue = lodash.get(value, 'attributes.defaultValue', value.kind === 'number' ? 0 : '');
+            ctrl.fields = lodash.chain(ctrl.template.values)
+                .cloneDeep()
+                .forIn(function (field, key) {
+                    field.name = key;
+                })
+                .filter(function (field) {
+                    var kind = lodash.get(field, 'kind');
+                    return lodash.isString(kind) ? lodash.includes(FILED_KINDS, kind.toLowerCase()) : false;
+                })
+                .map(function (field) {
 
-                lodash.set(templateData, key, defaultValue);
+                    // converting `kind` property to lower-case in order to be more flexible, allowing the user to
+                    // specify kind in case-insensitive.
+                    field.kind = field.kind.toLowerCase();
 
-                if (value.kind === 'choice') {
-                    lodash.set(ctrl.dropdownOptions, key + '.options', prepareDropdownValue(lodash.get(value, 'attributes.choices')));
-                    lodash.set(ctrl.dropdownOptions, key + '.defaultValue', prepareDropdownValue(defaultValue));
-                }
-            });
+                    // setting default values to various properties
+                    lodash.defaults(field, {
+                        displayName: 'Unspecified field name',
+                        description: '',
+                        required: false,
+                        order: Infinity,
+                        attributes: lodash.defaults(field.attributes, defaultAttributes[field.kind])
+                    });
+
+                    if (field.kind === 'number') {
+                        if (!field.attributes.allowNegative && field.attributes.minValue < 0) {
+                            field.attributes.minValue = field.attributes.allowZero ? 0 : 1;
+                        }
+                    }
+
+                    if (field.kind === 'choice') {
+                        lodash.update(field, 'attributes.choices', function (choices) {
+                            return !lodash.isArray(choices) ? [] : lodash.map(choices, function (choice) {
+                                return lodash.isString(choice) ? {
+                                    id: choice,
+                                    name: choice,
+                                    visible: true
+                                } : choice;
+                            });
+                        });
+                    }
+
+                    return field;
+                })
+                .uniqBy('name') // prevent `ngRepeat` from breaking on duplicates.
+                .sortBy('order')
+                .forEach(function (field) {
+                    lodash.set(templateData, field.name, field.attributes.defaultValue);
+                })
+                .value();
         }
 
         //
@@ -65,8 +126,11 @@
          * @param {Event} [event]
          */
         function onApply(event) {
-            if ((angular.isUndefined(event) || event.keyCode === EventHelperService.ENTER) && !ctrl.isLoadingState) {
-                ctrl.closeDialog({template: templateData});
+            if (isFormFilled()) {
+                if ((angular.isUndefined(event) || event.keyCode === EventHelperService.ENTER) &&
+                    !ctrl.isLoadingState) {
+                    ctrl.closeDialog({ template: templateData });
+                }
             }
         }
 
@@ -95,29 +159,6 @@
         function dropdownCallback(newData, isChanged, field) {
             if (isChanged) {
                 lodash.set(templateData, field, newData.id);
-            }
-        }
-
-        //
-        // Private methods
-        //
-
-        /**
-         * Converts values for drop-down.
-         */
-        function prepareDropdownValue(value) {
-            if (lodash.isArray(value)) {
-                return lodash.map(value, function (option) {
-                    return {
-                        id: option,
-                        name: option
-                    };
-                });
-            } else if (lodash.isString(value)) {
-                return {
-                    id: value,
-                    name: value
-                }
             }
         }
     }

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.less
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.less
@@ -8,27 +8,33 @@
 
     .main-content {
         width: 300px;
+        max-height: 500px;
 
-        .field-label {
-            font-size: 14px;
-            text-align: left;
-            color: @dusk-three;
-        }
+        form {
+            margin: 0 20px 0 0;
 
-        .validating-input-field {
-            .input-field {
-                padding: 0 10px 0 17px;
-            }
-
-            .input-placeholder {
-                left: 18px;
-                font-style: italic;
+            .field-label {
                 font-size: 14px;
+                text-align: left;
+                color: @dusk-three;
+
+                .igz-icon-help-round::before {
+                    color: @dark-sky-blue;
+                    font-size: 18px;
+                }
+            }
+
+            .validating-input-field {
+                .input-field {
+                    padding: 0 10px 0 17px;
+                }
+
+                .input-placeholder {
+                    left: 18px;
+                    font-style: italic;
+                    font-size: 14px;
+                }
             }
         }
-    }
-
-    .ncl-primary-button {
-        cursor: pointer;
     }
 }

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.tpl.html
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.tpl.html
@@ -6,44 +6,51 @@
     </span>
 </div>
 
-<div class="main-content ">
+<div class="main-content igz-scrollable-container" data-ng-scrollbars>
     <form name="$ctrl.templateForm" novalidate>
         <div class="field-group"
-             data-ng-repeat="(name, value) in $ctrl.template.values">
+             data-ng-repeat="field in $ctrl.fields track by field.name">
             <div class="field-label">
-                {{ value.displayName }}
+                {{ field.displayName }} <span class="asterisk" data-ng-if="field.required"></span>
+                <span class="igz-icon-help-round pull-right pointer-cursor"
+                      data-uib-tooltip="{{field.description}}"
+                      data-tooltip-append-to-body="true"
+                      data-tooltip-placement="left"
+                      data-tooltip-popup-delay="200"
+                      data-ng-if="field.description"></span>
             </div>
 
-            <div data-ng-if="value.kind === 'string'">
+            <div data-ng-if="field.kind === 'string'">
                 <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="{{value.attributes.password ? 'password' : 'input'}}"
-                                            data-validation-is-required="value.required"
-                                            data-input-name="{{name}}"
+                                            data-field-type="{{field.attributes.password ? 'password' : 'input'}}"
+                                            data-validation-is-required="field.required"
+                                            data-input-value="field.attributes.defaultValue"
+                                            data-input-name="{{field.name}}"
                                             data-form-object="$ctrl.templateForm"
-                                            data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                            data-update-data-field="{{name}}"></igz-validating-input-field>
+                                            data-update-data-callback="$ctrl.inputValueCallback(newData, field)"></igz-validating-input-field>
             </div>
 
-            <div data-ng-if="value.kind === 'number'">
-                <igz-number-input data-min-value="value.attributes.minValue"
-                                  data-max-value="value.attributes.maxValue"
-                                  data-default-value="value.attributes.defaultValue"
-                                  data-validation-is-required="value.required"
+            <div data-ng-if="field.kind === 'number'">
+                <igz-number-input data-min-value="field.attributes.minValue"
+                                  data-max-value="field.attributes.maxValue"
+                                  data-value-step="field.attributes.step"
+                                  data-precision="{{field.attributes.allowDecimal ? 2 : 0}}"
+                                  data-default-value="field.attributes.defaultValue"
+                                  data-validation-is-required="field.required"
                                   data-form-object="$ctrl.templateForm"
                                   data-allow-empty-field="true"
                                   data-update-number-input-callback="$ctrl.inputValueCallback(newData, field)"
-                                  data-update-number-input-field="{{name}}"
-                                  data-input-name="{{name}}"
-                                  data-value-step="1"></igz-number-input>
+                                  data-input-name="{{field.name}}"></igz-number-input>
             </div>
 
-            <div data-ng-if="value.kind === 'choice'">
-                <igz-default-dropdown data-values-array="$ctrl.dropdownOptions[name].options"
-                                      data-selected-item="$ctrl.dropdownOptions[name].defaultValue"
-                                      data-is-required="value.required"
+            <div data-ng-if="field.kind === 'choice'">
+                <igz-default-dropdown data-values-array="field.attributes.choices"
+                                      data-selected-item="field.attributes.defaultValue"
+                                      data-select-property-only="id"
+                                      data-is-required="field.required"
                                       data-item-select-callback="$ctrl.dropdownCallback(item, isItemChanged, name)"
                                       data-form-object="$ctrl.templateForm"
-                                      data-input-name="{{name}}"></igz-default-dropdown>
+                                      data-input-name="{{field.name}}"></igz-default-dropdown>
             </div>
         </div>
     </form>
@@ -56,7 +63,8 @@
         Cancel
     </button>
     <button class="ncl-primary-button"
-            data-ng-class="{'disabled': !$ctrl.isFormFilled()}"
+            data-ng-class="{disabled: !$ctrl.isFormFilled()}"
+            data-ng-disabled="!$ctrl.isFormFilled()"
             data-ng-click="$ctrl.onApply()"
             data-ng-keydown="$ctrl.onApply($event)">
         Apply


### PR DESCRIPTION
Also:
- Add "more info" icon with contents of `description` in case it is non-empty.
- Add red asterisk in case `required` is `true`.
- Limit dialog's height and add vertical scrollbar.
- Skip params whose `kind` is not one of the defined available values (currently: `'string'`, `'number'` and `'choice'`).
- `kind` is now case-INsensitive.
- Ignore duplicate params by key. In case there are more than one params sharing the same key, then the first one will be used and the others will be skipped.
- Bugfix: "Apply" button works although it looks disabled.