### PR TITLE
Fix [Nuclio] Triggers>RabbitMQ>Topics: wrong value when empty

### DIFF
--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -850,8 +850,8 @@
                                     lodash.set(ctrl.item, 'attributes[' + attribute.name + ']', numberAttribute);
                                 }
 
-                                if (attribute.pattern === 'arrayStr' && !lodash.isArray(ctrl.item.attributes[attribute.name])) {
-                                    ctrl.item.attributes[attribute.name] = ctrl.item.attributes[attribute.name].split(',');
+                                if (attribute.pattern === 'arrayStr') {
+                                    lodash.update(ctrl.item.attributes, attribute.name, ConverterService.toStringArray);
                                 }
 
                                 if (attribute.pattern === 'arrayInt' && !lodash.isArray(ctrl.item.attributes[attribute.name])) {

--- a/src/nuclio/common/services/converter.service.js
+++ b/src/nuclio/common/services/converter.service.js
@@ -8,7 +8,8 @@
 
     function ConverterService(lodash) {
         return {
-            toNumberArray: toNumberArray
+            toNumberArray: toNumberArray,
+            toStringArray: toStringArray
         };
 
         //
@@ -53,6 +54,50 @@
                 .uniq() // get rid of duplicate values (e.g. `[1, 2, 2, 3, 4, 4, 5]` to `[1, 2, 3, 4, 5]`)
                 .sortBy() // sort the list in ascending order (e.g. `[4, 1, 5, 3, 2, 6]` to`[1, 2, 3, 4, 5, 6]`)
                 .value();
+        }
+
+        /**
+         * Converts a `string` consisting of a comma-delimited list into an array of strings (whitespace is trimmed).
+         * If `value` is not a `string`, it will be returned as-is.
+         * @param {string|*} value - the string to convert.
+         * @returns {Array.<string>|*} an array of strings representing the comma-delimited list in `value`, or `value`
+         *     as-is if it is not a `string`.
+         * @example
+         * toStringArray('  foo,bar   ,  baz,  waz  ,bla  ');
+         * // => ['foo', 'bar', 'baz', 'waz', 'bla']
+         *
+         * toStringArray('  ,  ');
+         * // => []
+         *
+         * toStringArray('    ');
+         * // => []
+         *
+         * toStringArray('');
+         * // => []
+         *
+         * toStringArray(123);
+         * // => 123
+         *
+         * toStringArray(false);
+         * // => false
+         *
+         * toStringArray({ foo: 'bar' });
+         * // => { foo: 'bar' }
+         *
+         * toStringArray([123, 456]);
+         * // => [123, 456]
+         *
+         * toStringArray(/abc/g);
+         * // => abc/g
+         *
+         * toStringArray(null);
+         * // => null
+         *
+         * toStringArray(undefined);
+         * // => undefined
+         */
+        function toStringArray(value) {
+            return lodash.isString(value) ? lodash.without(value.trim().split(/\s*,\s*/), '') : value;
         }
     }
 }());


### PR DESCRIPTION
When the field is empty the model value should be an empty array: `[]`.
Instead, if was an array with a single item, an empty string: `['']`.