### PR TITLE
Fix [Nuclio] Test pane logs: visual bug on expanding entry

### DIFF
--- a/src/nuclio/projects/project/functions/version/version-code/function-event-pane/test-events-logs/test-events-logs.less
+++ b/src/nuclio/projects/project/functions/version/version-code/function-event-pane/test-events-logs/test-events-logs.less
@@ -35,6 +35,10 @@
             font-size: 12px;
             color: @color;
             margin: 0 8px 0 12px;
+
+            &::before {
+                vertical-align: text-bottom;
+            }
         }
 
         .level-icon {
@@ -43,14 +47,15 @@
             width: 20px;
             text-align: center;
 
-            &:before {
+            &::before {
                 font-size: 16px;
+                vertical-align: text-bottom;
             }
 
             &.ncl-icon-debug {
                 color: @orangish;
 
-                &:before {
+                &::before {
                     font-size: 18px;
                 }
             }
@@ -102,13 +107,17 @@
             position: relative;
             display: flex;
             align-items: center;
-            height: 36px;
+            height: 34px;
 
             .igz-icon-down {
                 .duskThree(0.64);
                 font-size: 12px;
                 color: @color;
                 margin: 0 8px 0 12px;
+
+                &::before {
+                    vertical-align: text-bottom;
+                }
             }
 
             .level-icon {
@@ -117,14 +126,15 @@
                 width: 20px;
                 text-align: center;
 
-                &:before {
+                &::before {
                     font-size: 16px;
+                    vertical-align: text-bottom;
                 }
 
                 &.ncl-icon-debug {
                     color: @orangish;
 
-                    &:before {
+                    &::before {
                         font-size: 18px;
                     }
                 }


### PR DESCRIPTION
- Entry header moves a few pixels on collapse/expand.
- Collapse/expand icons and log level icons are not vertically aligned.

![image](https://user-images.githubusercontent.com/13918850/51549767-b2b83600-1e73-11e9-8fc8-d4829652cdc2.png)
![image](https://user-images.githubusercontent.com/13918850/51549793-bba90780-1e73-11e9-873e-37c25898f77a.png)
