### PR TITLE
Fix igzInputOnlyValidCharacters directive

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
@@ -22,7 +22,7 @@
                data-ng-disabled="$ctrl.isDisabled"
                data-ng-keydown="$ctrl.keyDown($event)"
                data-igz-input-only-valid-characters="$ctrl.validationPattern"
-               data-only-valid-characters="{{$ctrl.onlyValidCharacters}}"
+               data-only-valid-characters="$ctrl.onlyValidCharacters"
                spellcheck="{{$ctrl.spellcheck}}"
                maxlength="{{$ctrl.onlyValidCharacters ? $ctrl.validationMaxLength : null}}"
                data-igz-input-blur-on-enter>

--- a/src/igz_controls/directives/input-only-valid-characters.js
+++ b/src/igz_controls/directives/input-only-valid-characters.js
@@ -9,13 +9,15 @@
             restrict: 'A',
             require: 'ngModel',
             scope: {
-                pattern: '=igzInputOnlyValidCharacters'
+                pattern: '=igzInputOnlyValidCharacters',
+                onlyValidCharacters: '=onlyValidCharacters'
             },
             link: link
         };
 
         function link(scope, element, attr, ngModelCtrl) {
             var REGEXP = scope.pattern;
+            var onlyValidCharacters = scope.onlyValidCharacters;
             var lastValidViewValue;
 
             activate();
@@ -41,7 +43,7 @@
              * @returns {string} the last valid entered value
              */
             function checkForDigits(viewValue) {
-                if (attr.onlyValidCharacters) {
+                if (onlyValidCharacters) {
                     if (REGEXP.test(viewValue)) {
 
                         // Saves as valid view value if it's a not empty string


### PR DESCRIPTION
When `onlyValidCharacters` is passed with the string `'false'`, the validation also occurs. The only way to make it not occur is to not provide the `onlyValidCharacters` attribute at all.

Bug discovered only after merging PR https://github.com/iguazio/dashboard-controls/pull/482