### PR TITLE
Fix [General] Tooltips flickr when they open over the mouse cursor

### DIFF
--- a/src/igz_controls/less/tooltips.less
+++ b/src/igz_controls/less/tooltips.less
@@ -97,6 +97,7 @@
 
     transition-duration: 0s;
     z-index: 10001;
+    pointer-events: none;
 
     .tooltip-arrow {
         display: none;


### PR DESCRIPTION
Replaces PR https://github.com/iguazio/dashboard-controls/pull/495 which was mistakenly merged into `master` branch.