### PR TITLE
Impl [Nuclio] Create function from scratch: Remove some defaults

### DIFF
--- a/src/igz_controls/components/slider-input-block/slider-input-block.less
+++ b/src/igz_controls/components/slider-input-block/slider-input-block.less
@@ -53,13 +53,16 @@
                 height: 14px;
                 width: 14px;
                 top: -6px;
-                background-color: @rz-pointer-bg-color;
                 box-shadow: @rz-pointer-box-shadow;
                 outline: 0;
 
                 &:after {
                     display: none;
                 }
+            }
+
+            &:not([disabled]) .rz-pointer {
+                background-color: @rz-pointer-bg-color;
             }
         }
     }

--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
@@ -286,10 +286,7 @@
                     runtime: ctrl.selectedRuntime.id,
                     build: {
                         functionSourceCode: ctrl.selectedRuntime.sourceCode
-                    },
-                    targetCPU: 75,
-                    minReplicas: 1,
-                    maxReplicas: 1
+                    }
                 }
             };
 

--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.less
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.less
@@ -53,7 +53,8 @@
             }
 
             .slider-row {
-                width: 74%;
+                width: 65%;
+                margin-left: 15px;
             }
         }
     }

--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
@@ -140,9 +140,9 @@
                                           data-placeholder=""
                                           data-decimal-number="0"
                                           data-value-step="1"
-                                          data-validation-is-required="true"
+                                          data-validation-is-required="false"
                                           data-min-value="0"
-                                          data-max-value="$ctrl.maxReplicas"></igz-number-input>
+                                          data-max-value="$ctrl.maxReplicas || Infinity"></igz-number-input>
                     </div>
                 </div>
 
@@ -158,14 +158,26 @@
                                           data-placeholder=""
                                           data-decimal-number="0"
                                           data-value-step="1"
-                                          data-validation-is-required="true"
-                                          data-min-value="$ctrl.minReplicas"></igz-number-input>
+                                          data-validation-is-required="false"
+                                          data-min-value="$ctrl.minReplicas || 1"></igz-number-input>
                     </div>
                 </div>
             </div>
 
             <div class="igz-row form-row range-inputs-row slider-block">
                 <div class="igz-col-10 row-title target-cpu-title">Target CPU</div>
+                <input type="checkbox"
+                       class="small"
+                       id="target-cpu-toggle"
+                       data-ng-true-value="false"
+                       data-ng-false-value="true"
+                       data-ng-model="$ctrl.targetCpuSliderConfig.options.disabled"
+                       data-ng-change="$ctrl.toggleTargetCpu()">
+                <label for="target-cpu-toggle" class="checkbox-inline"
+                       data-uib-tooltip="{{$ctrl.targetCpuSliderConfig.options.disabled ? 'Click to enable' : 'Click to disable'}}"
+                       data-tooltip-append-to-body="true"
+                       data-tooltip-placement="top"
+                       data-tooltip-popup-delay="500">&nbsp;</label>
                 <div class="slider-row">
                     <igz-slider-input-block data-slider-config="$ctrl.targetCpuSliderConfig"
                                             data-measure-units="null"


### PR DESCRIPTION
When using remote code-entry type like Archive or GitHub, the values entered in UI have precedence over the values that come from the remote configuration. There were some default values in UI when creating a function from scratch that overrode values from remote configuration non-intendedly.
Min Replicas, Max Replicas, and Target CPU should not have default values for new functions.