### PR TITLE
Fix [Nuclio] Latest changes not taken on Deploy

### DIFF
--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-annotations/version-configuration-annotations.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-annotations/version-configuration-annotations.tpl.html
@@ -14,7 +14,9 @@
                                      data-use-type="false"
                                      data-item-index="$index"
                                      data-action-handler-callback="$ctrl.handleAction(actionType, index)"
-                                     data-change-data-callback="$ctrl.onChangeData(newData, index)"></ncl-key-value-input>
+                                     data-change-data-callback="$ctrl.onChangeData(newData, index)"
+                                     data-submit-on-fly="true">
+                </ncl-key-value-input>
             </div>
         </div>
         <div data-ng-if="$ctrl.isScrollNeeded()"

--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.tpl.html
@@ -14,7 +14,9 @@
                                      data-all-value-types="$ctrl.isOnlyValueTypeInputs"
                                      data-action-handler-callback="$ctrl.handleAction(actionType, index)"
                                      data-change-data-callback="$ctrl.onChangeData(newData, index)"
-                                     data-dropdown-overlap="true"></ncl-key-value-input>
+                                     data-dropdown-overlap="true"
+                                     data-submit-on-fly="true">
+                </ncl-key-value-input>
             </div>
         </div>
         <div data-ng-if="$ctrl.isScrollNeeded()"

--- a/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.tpl.html
+++ b/src/nuclio/projects/project/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.tpl.html
@@ -14,7 +14,9 @@
                                      data-item-index="$index"
                                      data-use-type="false"
                                      data-action-handler-callback="$ctrl.handleAction(actionType, index)"
-                                     data-change-data-callback="$ctrl.onChangeData(newData, index)"></ncl-key-value-input>
+                                     data-change-data-callback="$ctrl.onChangeData(newData, index)"
+                                     data-submit-on-fly="true">
+                </ncl-key-value-input>
             </div>
         </div>
 


### PR DESCRIPTION
In Annotations, Labels and Environment Variables key-value lists, when an input field is focused and its value it changed by the user, then the user clicks on the "Deploy" button — the latest changes to the focused input field are not present in the PUT request. This is because these key-value lists were set to be updated only on clicking anywhere in the document outside of these elements, or on pressing the Enter key.

Now, the changes are in effect immediately when making the change.