### PR TITLE
[Build] Deprecate gulp-util (use fancy-log and ansi-colors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
         "gulp-rev": "^6.0.1",
         "gulp-rev-collector": "^1.0.2",
         "gulp-uglify": "^1.4.1",
-        "gulp-util": "^3.0.4",
         "i18next": "^15.1.3",
         "jquery": "*",
         "jquery-ui": "1.12.0",


### PR DESCRIPTION
Implements Trello ticket [[Build] Deprecate gulp-util (use fancy-log and ansi-colors)](https://trello.com/c/Fp9DsdA0)

Replaces PR #662 that was mistakenly merged into `master` branch instead of `development` branch.