### PR TITLE
[Nuclio] Function status icon hides for small browser resolution

### DIFF
--- a/src/nuclio/projects/project/functions/function-collapsing-row/function-collapsing-row.less
+++ b/src/nuclio/projects/project/functions/function-collapsing-row/function-collapsing-row.less
@@ -58,6 +58,10 @@
             font-weight: bold;
         }
 
+        .function-status {
+            min-width: 100px;
+        }
+
         .actions-menu {
             visibility: hidden;
         }

--- a/src/nuclio/projects/project/functions/function-collapsing-row/function-collapsing-row.tpl.html
+++ b/src/nuclio/projects/project/functions/function-collapsing-row/function-collapsing-row.tpl.html
@@ -19,7 +19,7 @@
                 {{$ctrl.function.metadata.name}}
             </div>
 
-            <div class="igz-col-{{$ctrl.isDemoMode() ? '7-5' : '10'}} common-table-cell">
+            <div class="igz-col-{{$ctrl.isDemoMode() ? '7-5' : '10'}} common-table-cell function-status">
                 {{$ctrl.convertedStatusState}}
                 <div class="status-icon"
                      data-uib-tooltip="{{$ctrl.getTooltip()}}"

--- a/src/nuclio/projects/project/functions/function.less
+++ b/src/nuclio/projects/project/functions/function.less
@@ -10,4 +10,8 @@ ncl-functions {
     .invisible {
         visibility: hidden;
     }
+
+    .function-status {
+        min-width: 100px;
+    }
 }

--- a/src/nuclio/projects/project/functions/functions.tpl.html
+++ b/src/nuclio/projects/project/functions/functions.tpl.html
@@ -69,7 +69,7 @@
                         {{ 'common:NAME' | i18next }}
                         <span class="sort-arrow"></span>
                     </div>
-                    <div class="igz-col-{{$ctrl.isDemoMode() ? '7-5' : '10'}} common-table-cell sortable"
+                    <div class="igz-col-{{$ctrl.isDemoMode() ? '7-5' : '10'}} common-table-cell sortable function-status"
                          data-ng-class="$ctrl.getColumnSortingClasses('status.state', $ctrl.sortedColumnName, $ctrl.isReverseSorting)"
                          data-ng-click="$ctrl.sortTableByColumn('status.state')">
                         {{ 'common:STATUS' | i18next }}


### PR DESCRIPTION
Resolves Trello ticket [[Nuclio] Function status icon hides for small browser resolution](https://trello.com/c/bA9iINo8)