### PR TITLE
Invocation per second calculation fix

### DIFF
--- a/src/nuclio/projects/project/functions/functions.component.js
+++ b/src/nuclio/projects/project/functions/functions.component.js
@@ -537,19 +537,21 @@
                         // calculating of invocation per second regarding last timestamps
                         var invocationPerSec = lodash.chain(funcStats)
                             .map(function (stat) {
+                                var firstValue;
+                                var secondValue;
 
-                                // stubs, handling arrays of length 1
-                                var firstValue = [0, 0];
-                                var secondValue = [0, 1];
+                                if (stat.valus.length < 2) {
+                                    return 0;
+                                }
 
-                                if (stat.valus.length === 2) {
-                                    firstValue = stat.values[0];
-                                    secondValue = stat.values[1];
+                                // handle array of length 2
+                                firstValue = stat.values[0];
+                                secondValue = stat.values[1];
 
                                 // when querying up to current time prometheus
                                 // may duplicate the last value, so we calculate an earlier
                                 // interval [pre-last] to get a meaningful value
-                                } else if (stat.valus.length > 2) {
+                                if (stat.valus.length > 2) {
                                     firstValue = stat.values[stat.values.length - 3];
                                     secondValue = stat.values[stat.values.length - 2];
                                 }

--- a/src/nuclio/projects/project/functions/functions.component.js
+++ b/src/nuclio/projects/project/functions/functions.component.js
@@ -537,11 +537,15 @@
                         // calculating of invocation per second regarding last timestamps
                         var invocationPerSec = lodash.chain(funcStats)
                             .map(function (stat) {
-                                var lastStat = lodash.last(stat.values);
-                                var preLastStat = stat.values[stat.values.length - 2];
 
-                                var valuesDiff = Number(lastStat[1]) - Number(preLastStat[1]);
-                                var timestampsDiff = lastStat[0] - preLastStat[0];
+                                // when querying up to current time prometheus
+                                // may duplicate the last value, so we calculate an earlier
+                                // interval [pre-last] to get a meaningful value
+                                var firstValue = stat.values[stat.values.length - 3];
+                                var secondValue = stat.values[stat.values.length - 2];
+
+                                var valuesDiff = Number(secondValue[1]) - Number(firstValue[1]);
+                                var timestampsDiff = secondValue[0] - firstValue[0];
 
                                 return valuesDiff / timestampsDiff;
                             })

--- a/src/nuclio/projects/project/functions/functions.component.js
+++ b/src/nuclio/projects/project/functions/functions.component.js
@@ -538,11 +538,21 @@
                         var invocationPerSec = lodash.chain(funcStats)
                             .map(function (stat) {
 
+                                // stubs, handling arrays of length 1
+                                var firstValue = [0, 0];
+                                var secondValue = [0, 1];
+
+                                if (stat.valus.length === 2) {
+                                    firstValue = stat.values[0];
+                                    secondValue = stat.values[1];
+
                                 // when querying up to current time prometheus
                                 // may duplicate the last value, so we calculate an earlier
                                 // interval [pre-last] to get a meaningful value
-                                var firstValue = stat.values[stat.values.length - 3];
-                                var secondValue = stat.values[stat.values.length - 2];
+                                } else if (stat.valus.length > 2) {
+                                    firstValue = stat.values[stat.values.length - 3];
+                                    secondValue = stat.values[stat.values.length - 2];
+                                }
 
                                 var valuesDiff = Number(secondValue[1]) - Number(firstValue[1]);
                                 var timestampsDiff = secondValue[0] - firstValue[0];


### PR DESCRIPTION
latest interval is zero in real world responses (same value duplicated in 2 latest metric values), taking the interval before last