### PR TITLE
Fix [General] Scale filter: values<1 return wrong result (nanos)

### DIFF
--- a/src/igz_controls/services/scale.filter.js
+++ b/src/igz_controls/services/scale.filter.js
@@ -10,7 +10,7 @@
                 { threshold: 1000000000, unit: '' },
                 { threshold: 1000000, unit: 'm' },
                 { threshold: 1000, unit: 'µ' },
-                { threshold: 0.05, unit: 'n' },
+                { threshold: 0.05, unit: 'n', divisor: 1 },
                 '0'
             ],
             'default': [


### PR DESCRIPTION
Relates to PR #763 