### PR TITLE
[Services] Use `name` instead of `display_name`

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.js
@@ -278,7 +278,7 @@
                 });
             }
 
-            if (angular.isDefined(ctrl.validationRules) && !lodash.isEmpty(ctrl.data)) {
+            if (angular.isDefined(ctrl.validationRules)) {
                 checkPatternsValidity(ctrl.data);
             }
         }


### PR DESCRIPTION
Implements Trello ticket [[Services] Use `name` instead of `display_name`](https://trello.com/c/kJgy7KKh)