### PR TITLE
[Services] Wizard: name is always invalid after type selected

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.js
@@ -176,6 +176,10 @@
                 if (!changes.inputValue.isFirstChange()) {
                     ctrl.data = angular.copy(changes.inputValue.currentValue);
                     ctrl.startValue = angular.copy(ctrl.inputValue);
+
+                    if (angular.isDefined(ctrl.validationRules)) {
+                        checkPatternsValidity(ctrl.data, false);
+                    }
                 }
             }
 


### PR DESCRIPTION
https://trello.com/c/lUWDJ7ST/247-services-wizard-name-is-always-invalid-after-type-selected