### PR TITLE
Impl [Nuclio] Triggers: Max workers as number input + limit

### DIFF
--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -757,7 +757,7 @@
             }
 
             if (!lodash.isNil(item.maxWorkers)) {
-                ctrl.item.maxWorkers = '';
+                ctrl.item.maxWorkers = item.maxWorkers.defaultValue;
             }
 
             if (!lodash.isNil(item.secret)) {
@@ -778,10 +778,6 @@
 
             if (!lodash.isNil(item.password)) {
                 ctrl.item.password = '';
-            }
-
-            if (!lodash.isNil(item.workerAvailabilityTimeoutMilliseconds)) {
-                ctrl.item.workerAvailabilityTimeoutMilliseconds = item.workerAvailabilityTimeoutMilliseconds.defaultValue;
             }
 
             lodash.each(item.attributes, function (attribute) {

--- a/src/nuclio/common/components/edit-item/edit-item.tpl.html
+++ b/src/nuclio/common/components/edit-item/edit-item.tpl.html
@@ -219,18 +219,19 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.maxWorkers)">
                 <div class="field-label">{{ 'functions:MAX_WORKERS' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
-                                            data-input-name="itemMaxWorkers"
-                                            data-input-value="$ctrl.item.maxWorkers"
-                                            data-is-focused="false"
-                                            data-form-object="$ctrl.editItemForm"
-                                            data-validation-pattern="$ctrl.numberValidationPattern"
-                                            data-validation-is-required="true"
-                                            data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_MAX_WORKERS' | i18next }}"
-                                            data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                            data-update-data-field="maxWorkers">
-                </igz-validating-input-field>
+                <igz-number-input data-form-object="$ctrl.editItemForm"
+                                  data-input-name="{{$ctrl.selectedClass.maxWorkers.name}}"
+                                  data-current-value="$ctrl.item.maxWorkers"
+                                  data-update-number-input-callback="$ctrl.numberInputCallback(newData, field)"
+                                  data-update-number-input-field="maxWorkers"
+                                  data-placeholder="{{ 'functions:PLACEHOLDER.ENTER_MAX_WORKERS' | i18next }}"
+                                  data-decimal-number="0"
+                                  data-value-step="1"
+                                  data-validation-is-required="!$ctrl.selectedClass.maxWorkers.allowEmpty"
+                                  data-allow-empty-field="$ctrl.selectedClass.maxWorkers.allowEmpty"
+                                  data-min-value="$ctrl.selectedClass.maxWorkers.min"
+                                  data-max-value="$ctrl.selectedClass.maxWorkers.max">
+                </igz-number-input>
             </div>
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.workerAvailabilityTimeoutMilliseconds)">
@@ -245,7 +246,7 @@
                                   data-value-step="1"
                                   data-validation-is-required="!$ctrl.selectedClass.workerAvailabilityTimeoutMilliseconds.allowEmpty"
                                   data-allow-empty-field="$ctrl.selectedClass.workerAvailabilityTimeoutMilliseconds.allowEmpty"
-                                  data-min-value="0">
+                                  data-min-value="$ctrl.selectedClass.workerAvailabilityTimeoutMilliseconds.min">
                 </igz-number-input>
 
             </div>

--- a/src/nuclio/projects/project/functions/functions.service.js
+++ b/src/nuclio/projects/project/functions/functions.service.js
@@ -25,6 +25,17 @@
                     {
                         id: 'kafka-cluster',
                         name: 'Kafka',
+                        tooltip: 'Kafka',
+                        tooltipPlacement: 'right',
+                        maxWorkers: {
+                            name: 'maxWorkers',
+                            pattern: 'number',
+                            type: 'number-input',
+                            allowEmpty: false,
+                            min: 1,
+                            max: 100000,
+                            defaultValue: 1
+                        },
                         attributes: [
                             {
                                 name: 'kafka-topics',
@@ -147,6 +158,25 @@
                     {
                         id: 'cron',
                         name: 'Cron',
+                        tooltip: 'Cron',
+                        tooltipPlacement: 'right',
+                        maxWorkers: {
+                            name: 'maxWorkers',
+                            pattern: 'number',
+                            type: 'number-input',
+                            allowEmpty: false,
+                            min: 1,
+                            max: 100000,
+                            defaultValue: 1
+                        },
+                        workerAvailabilityTimeoutMilliseconds: {
+                            name: 'workerAvailabilityTimeoutMilliseconds',
+                            pattern: 'number',
+                            type: 'number-input',
+                            allowEmpty: false,
+                            min: 0,
+                            defaultValue: 0
+                        },
                         attributes: [
                             {
                                 name: 'interval',
@@ -229,12 +259,23 @@
                     {
                         id: 'http',
                         name: 'HTTP',
-                        maxWorkers: 'number',
+                        tooltip: 'HTTP',
+                        tooltipPlacement: 'right',
+                        maxWorkers: {
+                            name: 'maxWorkers',
+                            pattern: 'number',
+                            type: 'number-input',
+                            allowEmpty: false,
+                            min: 1,
+                            max: 100000,
+                            defaultValue: 1
+                        },
                         workerAvailabilityTimeoutMilliseconds: {
                             name: 'workerAvailabilityTimeoutMilliseconds',
                             pattern: 'number',
                             type: 'number-input',
                             allowEmpty: false,
+                            min: 0,
                             defaultValue: 0
                         },
                         attributes: [


### PR DESCRIPTION
- Turn Max Workers to a number input field
- Add Max Workers field to Cron and Kafka trigger kinds
- Add Worker Availability Timeout Millis field to Cron trigger kind

PR to development branch: https://github.com/iguazio/dashboard-controls/pull/868