### PR TITLE
[Nuclio] Status column sorts only after second click

### DIFF
--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -249,6 +249,8 @@
                                         status === 'Ready' && ctrl.function.spec.disable  ? 'Standby'        :
                                         status === 'Ready' && !ctrl.function.spec.disable ? 'Running'        :
                                         /* else */                                          'Building';
+
+            lodash.set(ctrl.function, 'ui.convertedStatus', ctrl.convertedStatusState);
         }
 
         /**

--- a/src/nuclio/functions/functions.tpl.html
+++ b/src/nuclio/functions/functions.tpl.html
@@ -80,9 +80,9 @@
                         <span class="sort-arrow"></span>
                     </div>
                     <div class="common-table-cell sortable function-status"
-                         data-ng-class="[$ctrl.getColumnSortingClasses('status.state', $ctrl.sortedColumnName, $ctrl.isReverseSorting),
+                         data-ng-class="[$ctrl.getColumnSortingClasses('ui.convertedStatus', $ctrl.sortedColumnName, $ctrl.isReverseSorting),
                                          $ctrl.getFunctionsTableColSize('status')]"
-                         data-ng-click="$ctrl.sortTableByColumn('status.state')">
+                         data-ng-click="$ctrl.sortTableByColumn('ui.convertedStatus')">
                         {{ 'common:STATUS' | i18next }}
                         <span class="sort-arrow"></span>
                     </div>


### PR DESCRIPTION
Resolves Trello ticket [[Nuclio] Status column sorts only after second click](https://trello.com/c/KgWIF1uX)