### PR TITLE
Impl [igzValidatingInputField] Refactor component to use ngModel

### DIFF
--- a/src/igz_controls/components/action-menu/action-menu.component.js
+++ b/src/igz_controls/components/action-menu/action-menu.component.js
@@ -96,6 +96,9 @@
             detachDocumentEvent();
         }
 
+        /**
+         * Post linking method
+         */
         function postLink() {
 
             // Bind DOM-related preventDropdownCutOff method to component's controller

--- a/src/igz_controls/components/info-page/info-page-content/info-page-content.component.js
+++ b/src/igz_controls/components/info-page/info-page-content/info-page-content.component.js
@@ -44,7 +44,7 @@
         }
 
         /**
-         * Linking method
+         * Post linking method
          */
         function postLink() {
             $timeout(function () {

--- a/src/igz_controls/components/validating-input-field/validating-input-field.less
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.less
@@ -75,30 +75,24 @@
         position: relative;
         width: 100%;
         z-index: 2;
+        outline: transparent none 0;
+        box-shadow: none;
 
         &:not([disabled]):not([readonly]) {
-            &:focus.ng-invalid:not(.ng-pristine), &.ng-invalid.ng-touched {
-                background-color: @input-textarea-field-not-disabled-focus-invalid-bg-color;
-                border: @input-textarea-field-not-disabled-focus-invalid-border;
-                box-shadow: none;
-                outline: none;
-            }
-
             &:focus {
-                outline: 0;
                 border: @input-textarea-field-not-disabled-hover-focus-border;
             }
 
-            &.invalid {
-                background-color: @input-textarea-field-not-disabled-invalid-bg-color;
-                border: @input-textarea-field-not-disabled-invalid-border;
-                box-shadow: none;
-            }
+            &.ng-invalid.ng-dirty, &.invalid.ng-dirty {
+                &:focus {
+                    background-color: @input-textarea-field-not-disabled-focus-invalid-bg-color;
+                    border: @input-textarea-field-not-disabled-focus-invalid-border;
+                }
 
-            &:focus.ng-valid, &:focus.ng-pristine {
-                border: @input-textarea-field-not-disabled-valid-border;
-                box-shadow: none;
-                outline: none;
+                &:not(:focus) {
+                    background-color: @input-textarea-field-not-disabled-invalid-bg-color;
+                    border: @input-textarea-field-not-disabled-invalid-border;
+                }
             }
         }
     }
@@ -263,6 +257,27 @@
 
         .textarea-field {
             padding: 7px 30px 6px 10px;
+        }
+    }
+}
+
+// an invalid input field should be displayed as invalid in case it is in a submitted form even if the field is pristine
+form.ng-submitted .validating-input-field {
+    .validating-input-field-color-set();
+
+    .input-field, .textarea-field {
+        &:not([disabled]):not([readonly]) {
+            &.ng-invalid, &.invalid {
+                &:focus {
+                    background-color: @input-textarea-field-not-disabled-focus-invalid-bg-color;
+                    border: @input-textarea-field-not-disabled-focus-invalid-border;
+                }
+
+                &:not(:focus) {
+                    background-color: @input-textarea-field-not-disabled-invalid-bg-color;
+                    border: @input-textarea-field-not-disabled-invalid-border;
+                }
+            }
         }
     }
 }

--- a/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
@@ -34,7 +34,6 @@
                data-only-valid-characters="$ctrl.onlyValidCharacters"
                spellcheck="{{$ctrl.spellcheck}}"
                autocomplete="{{$ctrl.autoComplete}}"
-               maxlength="{{$ctrl.onlyValidCharacters ? $ctrl.validationMaxLength : null}}"
                data-igz-input-blur-on-enter>
 
         <span data-ng-if="$ctrl.inputIcon" class="input-icon {{$ctrl.inputIcon}}"></span>
@@ -131,7 +130,8 @@
     </div>
 
     <div data-ng-if="$ctrl.fieldType === 'schedule'">
-        <cron-selection data-ng-class="{'invalid': $ctrl.isFieldValid()}"
+        <cron-selection class="field"
+                        data-ng-class="{'invalid': $ctrl.isFieldValid()}"
                         data-ng-model="$ctrl.data"
                         data-ng-change="$ctrl.updateInputValue()"
                         name="{{$ctrl.inputName}}">

--- a/src/igz_controls/services/dialogs.service.js
+++ b/src/igz_controls/services/dialogs.service.js
@@ -237,7 +237,7 @@
                 igzDialogPromptForm: {},
                 checkInput: function () {
                     if (angular.isDefined(validation) || required) {
-                        data.igzDialogPromptForm.$submitted = true;
+                        data.igzDialogPromptForm.$setSubmitted();
                     }
                     return data.igzDialogPromptForm.$valid;
                 },

--- a/src/igz_controls/services/form-validation.service.js
+++ b/src/igz_controls/services/form-validation.service.js
@@ -11,8 +11,13 @@
             isShowFieldInvalidState: isShowFieldInvalidState,
             isShowFieldError: isShowFieldError,
             isFormValid: isFormValid,
-            isFieldValid: isFieldValid
+            isFieldValid: isFieldValid,
+            validateAllFields: validateAllFields
         };
+
+        //
+        // Public methods
+        //
 
         /**
          * Check if the form is in an invalid state
@@ -76,6 +81,31 @@
             var elementValid = lodash.get(form, elementName + '.$valid', true);
 
             return (lodash.defaultTo(validateOnSubmit, false) && !formSubmitted) || elementValid;
+        }
+
+        /**
+         * Validates all the fields of a form. Recursively validates fields in nested forms (both immediate and deep).
+         * @param {Object} form - The form controller (`ngForm`).
+         */
+        function validateAllFields(form) {
+            lodash.invokeMap(getFields(form), '$validate');
+        }
+
+        //
+        // Private functions
+        //
+
+        /**
+         * Returns a list of all controls (immediate and nested) of the provided control in case it is a form
+         * (`ngForm`), or the control itself in case it is a field (`ngModel`).
+         * @param {Object} control - The form controller (`ngForm`) or the model controller (`ngForm`).
+         * @returns {Array.<Object>} An array of model controllers (`ngModel`) of all the fields of `control` in case it
+         *     is a form, or an array with `control` only in case it is a field.
+         */
+        function getFields(control) {
+            var controls =
+                lodash.hasIn(control, '$getControls') ? lodash.map(control.$getControls(), getFields) : [control];
+            return lodash.flattenDeep(controls);
         }
     }
 }());

--- a/src/igz_controls/services/validating-patterns.service.js
+++ b/src/igz_controls/services/validating-patterns.service.js
@@ -175,7 +175,7 @@
                     {
                         name: 'validCharacters',
                         label: $i18next.t('common:VALID_CHARACTERS', {lng: lng}) + ': a–z, A–Z, 0–9, -, _, .',
-                        pattern: /^[\w.-]+$/
+                        pattern: /^[\w.-]*$/
                     },
                     {
                         name: 'beginNot',

--- a/src/igz_controls/services/window-dimensions.service.js
+++ b/src/igz_controls/services/window-dimensions.service.js
@@ -7,7 +7,7 @@
     angular.module('iguazio.dashboard-controls')
         .factory('WindowDimensionsService', WindowDimensionsService);
 
-    function WindowDimensionsService($window, $document) {
+    function WindowDimensionsService($document, $window) {
         return {
             height: height,
             width: width,
@@ -34,16 +34,14 @@
          * Method removes class which sets overflow to hidden
          */
         function addOverflow() {
-            var elem = angular.element(document).find('body');
-            elem.removeClass('no-overflow');
+            $document.find('body').removeClass('no-overflow');
         }
 
         /**
          * Method adds class which sets overflow to hidden
          */
         function removeOverflow() {
-            var elem = angular.element(document).find('body');
-            elem.addClass('no-overflow');
+            $document.find('body').addClass('no-overflow');
         }
 
         /**

--- a/src/nuclio/common/components/edit-item/edit-item.tpl.html
+++ b/src/nuclio/common/components/edit-item/edit-item.tpl.html
@@ -4,8 +4,7 @@
           autocomplete="off">
         <div class="igz-row title-field-row">
             <div class="igz-col-20 name-field">
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="itemName"
                                             data-input-value="$ctrl.getInputValue()"
                                             data-is-focused="true"
@@ -51,9 +50,10 @@
             </div>
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.url)">
-                <div class="field-label">{{ 'common:URL' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <div class="field-label">
+                    <span class="asterisk">{{ 'common:URL' | i18next }}</span>
+                </div>
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="itemURL"
                                             data-input-value="$ctrl.item.url"
                                             data-is-focused="false"
@@ -69,13 +69,12 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.volumeMount.mountPath)">
                 <div class="field-label">
-                    <span>{{ 'functions:MOUNT_PATH' | i18next }}</span>
+                    <span class="asterisk">{{ 'functions:MOUNT_PATH' | i18next }}</span>
                     <igz-more-info data-description="{{ 'functions:MOUNT_PATH_DESCRIPTION' | i18next }}"
                                    data-trigger="click">
                     </igz-more-info>
                 </div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="itemPath"
                                             data-input-value="$ctrl.item.volumeMount.mountPath"
                                             data-is-focused="false"
@@ -92,13 +91,12 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.volume.flexVolume.options.accessKey)">
                 <div class="field-label">
-                    <span>{{ 'functions:ACCESS_KEY' | i18next }}</span>
+                    <span class="asterisk">{{ 'functions:ACCESS_KEY' | i18next }}</span>
                     <igz-more-info data-description="{{ 'functions:ACCESS_KEY_DESCRIPTION' | i18next }}"
                                    data-trigger="click">
                     </igz-more-info>
                 </div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="password"
+                <igz-validating-input-field data-field-type="password"
                                             data-auto-complete="current-password"
                                             data-input-name="secretRef"
                                             data-input-value="$ctrl.item.volume.flexVolume.options.accessKey"
@@ -115,13 +113,12 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.volume.flexVolume.options.container)">
                 <div class="field-label">
-                    <span>{{ 'functions:CONTAINER_NAME' | i18next }}</span>
+                    <span class="asterisk">{{ 'functions:CONTAINER_NAME' | i18next }}</span>
                     <igz-more-info data-description="{{ 'functions:CONTAINER_NAME_DESCRIPTION' | i18next }}"
                                    data-trigger="click">
                     </igz-more-info>
                 </div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="containerName"
                                             data-input-value="$ctrl.item.volume.flexVolume.options.container"
                                             data-is-focused="false"
@@ -142,8 +139,7 @@
                                    data-trigger="click">
                     </igz-more-info>
                 </div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="containerSubPath"
                                             data-input-value="$ctrl.item.volume.flexVolume.options.subPath"
                                             data-is-focused="false"
@@ -159,9 +155,10 @@
 
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.volume.hostPath.path)">
-                <div class="field-label">{{ 'functions:HOST_PATH' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <div class="field-label">
+                    <span class="asterisk">{{ 'functions:HOST_PATH' | i18next }}</span>
+                </div>
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="hostPath"
                                             data-input-value="$ctrl.item.volume.hostPath.path"
                                             data-is-focused="false"
@@ -175,9 +172,10 @@
 
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.volume.secret.secretName)">
-                <div class="field-label">{{ 'functions:SECRET_NAME' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <div class="field-label">
+                    <span class="asterisk">{{ 'functions:SECRET_NAME' | i18next }}</span>
+                </div>
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="secretName"
                                             data-input-value="$ctrl.item.volume.secret.secretName"
                                             data-is-focused="false"
@@ -191,9 +189,10 @@
 
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.volume.configMap.name)">
-                <div class="field-label">{{ 'functions:CONFIG_MAP_NAME' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <div class="field-label">
+                    <span class="asterisk">{{ 'functions:CONFIG_MAP_NAME' | i18next }}</span>
+                </div>
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="configMap"
                                             data-input-value="$ctrl.item.volume.configMap.name"
                                             data-is-focused="false"
@@ -207,9 +206,10 @@
 
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.volume.persistentVolumeClaim.claimName)">
-                <div class="field-label text-ellipsis">{{ 'functions:PERSISTENT_VOLUME_CLAIM_NAME' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <div class="field-label text-ellipsis">
+                    <span class="asterisk">{{ 'functions:PERSISTENT_VOLUME_CLAIM_NAME' | i18next }}</span>
+                </div>
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="persistentVolumeClaim"
                                             data-input-value="$ctrl.item.volume.persistentVolumeClaim.claimName"
                                             data-form-object="$ctrl.editItemForm"
@@ -222,7 +222,9 @@
 
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.maxWorkers)">
-                <div class="field-label">{{ 'functions:MAX_WORKERS' | i18next }}</div>
+                <div class="field-label">
+                    <span data-ng-class="{asterisk: !$ctrl.selectedClass.maxWorkers.allowEmpty}">{{ 'functions:MAX_WORKERS' | i18next }}</span>
+                </div>
                 <igz-number-input data-form-object="$ctrl.editItemForm"
                                   data-input-name="{{$ctrl.selectedClass.maxWorkers.name}}"
                                   data-current-value="$ctrl.item.maxWorkers"
@@ -240,7 +242,9 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.workerAvailabilityTimeoutMilliseconds)">
                 <div class="field-label">
-                    <span>{{ 'functions:WORKER_AVAILABILITY_TIMEOUT_MILLISECONDS' | i18next }}</span>
+                    <span data-ng-class="{
+                        asterisk: !$ctrl.selectedClass.workerAvailabilityTimeoutMilliseconds.allowEmpty
+                    }">{{ 'functions:WORKER_AVAILABILITY_TIMEOUT_MILLISECONDS' | i18next }}</span>
                     <igz-more-info data-description="{{ $ctrl.getWorkerAvailabilityTimeoutMillisecondsDescription() }}"
                                    data-trigger="click">
                     </igz-more-info>
@@ -263,9 +267,10 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && attribute.type === 'input' && attribute.name !== 'schedule'"
                  data-ng-repeat="attribute in $ctrl.selectedClass.attributes">
-                <div class="field-label">{{$ctrl.convertFromCamelCase(attribute.name)}}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="{{attribute.fieldType}}"
+                <div class="field-label">
+                    <span data-ng-class="{asterisk: !attribute.allowEmpty}">{{$ctrl.convertFromCamelCase(attribute.name)}}</span>
+                </div>
+                <igz-validating-input-field data-field-type="{{attribute.fieldType}}"
                                             data-input-name="item_{{attribute.name}}"
                                             data-input-value="$ctrl.getAttrValue(attribute.name)"
                                             data-is-focused="false"
@@ -297,7 +302,9 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && attribute.type === 'number-input'"
                  data-ng-repeat="attribute in $ctrl.selectedClass.attributes">
-                <div class="field-label">{{$ctrl.convertFromCamelCase(attribute.name)}}</div>
+                <div class="field-label">
+                    <span data-ng-class="{asterisk: !attribute.allowEmpty}">{{$ctrl.convertFromCamelCase(attribute.name)}}</span>
+                </div>
                 <igz-number-input data-form-object="$ctrl.editItemForm"
                                   data-input-name="{{attribute.name}}"
                                   data-current-value="$ctrl.getAttrValue(attribute.name)"
@@ -316,8 +323,7 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.username)">
                 <div class="field-label">{{ 'common:USERNAME' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="username"
                                             data-input-value="$ctrl.item.username"
                                             data-is-focused="false"
@@ -332,8 +338,7 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.password)">
                 <div class="field-label">{{ 'common:PASSWORD' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="password"
+                <igz-validating-input-field data-field-type="password"
                                             data-input-name="password"
                                             data-input-value="$ctrl.item.password"
                                             data-is-focused="false"
@@ -360,8 +365,7 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.attributes.sasl.user)">
                 <div class="field-label">{{ 'functions:SASL_USERNAME' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="itemSASLUsername"
                                             data-input-value="$ctrl.item.attributes.sasl.user"
                                             data-is-focused="false"
@@ -376,8 +380,7 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.attributes.sasl.password)">
                 <div class="field-label">{{ 'functions:SASL_PASSWORD' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="itemSASLPassword"
                                             data-input-value="$ctrl.item.attributes.sasl.password"
                                             data-is-focused="false"
@@ -392,8 +395,7 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && !$ctrl.isNil($ctrl.item.attributes.event.body)">
                 <div class="field-label">{{ 'functions:EVENT_BODY' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="eventBody"
                                             data-input-value="$ctrl.item.attributes.event.body"
                                             data-is-focused="false"
@@ -460,7 +462,6 @@
                         <ncl-key-value-input class="new-label-input"
                                              data-list-class="scrollable-annotations"
                                              data-change-state-broadcast="change-state-deploy-button"
-                                             data-key-optional="true"
                                              data-row-data="annotation"
                                              data-use-type="false"
                                              data-submit-on-fly="true"
@@ -481,7 +482,9 @@
             <div class="igz-col-91 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && $ctrl.isCronTrigger()">
 
-                <div class="field-label">{{ 'common:SCHEDULE' | i18next }}</div>
+                <div class="field-label">
+                    <span class="asterisk">{{ 'common:SCHEDULE' | i18next }}</span>
+                </div>
 
                 <div class="schedule-input-wrapper">
                     <igz-validating-input-field data-field-type="schedule"
@@ -516,7 +519,6 @@
                         <ncl-key-value-input class="new-label-input"
                                              data-list-class="scrollable-event-headers"
                                              data-change-state-broadcast="change-state-deploy-button"
-                                             data-key-optional="true"
                                              data-row-data="header"
                                              data-use-type="false"
                                              data-submit-on-fly="true"
@@ -629,8 +631,7 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="$ctrl.isClassSelected() && $ctrl.isTriggerType()">
                 <div class="field-label">{{ 'functions:WORKER_ALLOCATOR_NAME' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="itemWorkerAllocatorName"
                                             data-input-value="$ctrl.item.workerAllocatorName"
                                             data-is-focused="false"

--- a/src/nuclio/common/components/key-value-input/key-value-input.less
+++ b/src/nuclio/common/components/key-value-input/key-value-input.less
@@ -75,7 +75,7 @@
                 width: 29%;
 
                 .key-label {
-                    width: 40px;
+                    width: 45px;
                 }
 
                 .input-key {
@@ -97,10 +97,6 @@
 
                             &.invalid {
                                 border: 1px solid @darkish-pink;
-                            }
-
-                            &.invalid:hover {
-                                border: 1px solid @pale-grey;
                             }
                         }
                     }
@@ -136,10 +132,6 @@
 
                             &.invalid {
                                 border: 1px solid @darkish-pink;
-                            }
-
-                            &.invalid:hover {
-                                border: 1px solid @pale-grey;
                             }
                         }
                     }

--- a/src/nuclio/common/components/key-value-input/key-value-input.tpl.html
+++ b/src/nuclio/common/components/key-value-input/key-value-input.tpl.html
@@ -13,10 +13,10 @@
             <div class="input-container input-key-wrapper"
                  data-ng-if="!$ctrl.onlyValueInput"
                  data-ng-class="{'use-type': $ctrl.useType, 'all-value-types': $ctrl.allValueTypes}">
-                <label class="key-label" data-ng-if="$ctrl.useLabels">
+                <label class="key-label asterisk" data-ng-if="$ctrl.useLabels">
                     {{ 'common:KEY' | i18next }}:
                 </label>
-                <igz-validating-input-field class="nuclio-validating-input input-key"
+                <igz-validating-input-field class="input-key"
                                             data-ng-if="!$ctrl.keyList"
                                             data-field-type="input"
                                             data-input-name="key"
@@ -34,7 +34,7 @@
                                             data-tooltip-placement="bottom"
                                             data-tooltip-popup-delay="100">
                 </igz-validating-input-field>
-                <igz-default-dropdown class="nuclio-validating-input input-key"
+                <igz-default-dropdown class="input-key"
                                       data-ng-if="$ctrl.keyList"
                                       data-form-object="$ctrl.keyValueInputForm"
                                       data-prevent-drop-up="true"
@@ -78,7 +78,7 @@
                         {{ 'functions:CONFIGMAP_KEY' | i18next }}:
                     </span>
                 </label>
-                <igz-validating-input-field class="nuclio-validating-input input-value-key"
+                <igz-validating-input-field class="input-value-key"
                                             data-field-type="input"
                                             data-input-name="value-key"
                                             data-input-value="$ctrl.getInputKey()"
@@ -97,7 +97,7 @@
                                  'only-value-input': $ctrl.onlyValueInput,
                                  'only-key-value-input': $ctrl.isVisibleByType('value'),
                                  'all-value-types': $ctrl.allValueTypes}">
-                <label data-ng-if="$ctrl.useLabels">
+                <label data-ng-if="$ctrl.useLabels" class="asterisk">
                     <span data-ng-if="$ctrl.isVisibleByType('value')">
                         {{ 'common:VALUE' | i18next }}:
                     </span>
@@ -108,7 +108,7 @@
                         {{ 'functions:CONFIGMAP_NAME' | i18next }}:
                     </span>
                 </label>
-                <igz-validating-input-field class="nuclio-validating-input input-value"
+                <igz-validating-input-field class="input-value"
                                             data-field-type="input"
                                             data-input-name="value"
                                             data-input-value="$ctrl.getInputValue()"
@@ -125,7 +125,7 @@
                                             data-tooltip-placement="bottom"
                                             data-tooltip-popup-delay="100">
                 </igz-validating-input-field>
-                <igz-validating-input-field class="nuclio-validating-input input-additional-value"
+                <igz-validating-input-field class="input-additional-value"
                                             data-ng-if="$ctrl.useAdditionalValue && $ctrl.isVisibleByType('value')"
                                             data-field-type="input"
                                             data-input-name="additionalValue"

--- a/src/nuclio/common/less/general-rules.less
+++ b/src/nuclio/common/less/general-rules.less
@@ -5,14 +5,6 @@ body {
         height: 100%;
     }
 
-    .nuclio-validating-input {
-        .validating-input-field .input-field, .validating-input-field .textarea-field {
-            &:not([disabled]):not([readonly]):not(:focus):hover {
-                border: solid 1px @pale-grey;
-            }
-        }
-    }
-
     .table-headers {
         display: flex;
         font-size: 14px;

--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.tpl.html
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.tpl.html
@@ -28,8 +28,7 @@
                     <span class="input-label asterisk">
                         {{ 'common:NAME' | i18next }}
                     </span>
-                    <igz-validating-input-field class="nuclio-validating-input"
-                                                data-field-type="input"
+                    <igz-validating-input-field data-field-type="input"
                                                 data-input-name="name"
                                                 data-input-value="$ctrl.functionData.metadata.name"
                                                 data-validation-is-required="true"

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.tpl.html
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template-dialog/function-from-template-dialog.tpl.html
@@ -15,8 +15,7 @@
             </div>
 
             <div class="igz-col-55">
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-ng-if="field.kind === 'string'"
+                <igz-validating-input-field data-ng-if="field.kind === 'string'"
                                             data-field-type="{{field.attributes.password ? 'password' : 'input'}}"
                                             data-validation-is-required="field.required"
                                             data-input-value="field.attributes.defaultValue"

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template.tpl.html
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template.tpl.html
@@ -72,8 +72,7 @@
                                     <span class="input-label asterisk">
                                         {{ 'common:NAME' | i18next }}
                                     </span>
-                                    <igz-validating-input-field class="nuclio-validating-input"
-                                                                data-field-type="input"
+                                    <igz-validating-input-field data-field-type="input"
                                                                 data-input-name="function-name-{{$index}}"
                                                                 data-input-value="$ctrl.functionName"
                                                                 data-form-object="$ctrl.functionFromTemplateForm['templateForm' + $index]"

--- a/src/nuclio/common/screens/create-function/function-import/function-import.component.js
+++ b/src/nuclio/common/screens/create-function/function-import/function-import.component.js
@@ -50,7 +50,7 @@
          */
         function onInit() {
             $document.on('keypress', createFunction);
-            angular.element(document).find('.function-import-input').on('change', importFunction);
+            $document.find('.function-import-input').on('change', importFunction);
         }
 
         /**

--- a/src/nuclio/functions/duplicate-function-dialog/duplicate-function-dialog.component.js
+++ b/src/nuclio/functions/duplicate-function-dialog/duplicate-function-dialog.component.js
@@ -59,7 +59,7 @@
         function duplicateFunction(event) {
             if (angular.isUndefined(event) || event.keyCode === EventHelperService.ENTER) {
                 ctrl.nameTakenError = false;
-                ctrl.duplicateFunctionForm.$submitted = true;
+                ctrl.duplicateFunctionForm.$setSubmitted();
 
                 if (ctrl.duplicateFunctionForm.$valid) {
                     var newFunction = lodash.pick(ctrl.version, 'spec');

--- a/src/nuclio/functions/duplicate-function-dialog/duplicate-function-dialog.tpl.html
+++ b/src/nuclio/functions/duplicate-function-dialog/duplicate-function-dialog.tpl.html
@@ -11,8 +11,7 @@
                 {{ 'common:FUNCTION_NAME' | i18next }}
             </div>
             <div class="field-input function-name-input">
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="spec.displayName"
                                             data-input-value="$ctrl.newFunctionName"
                                             data-is-focused="true"

--- a/src/nuclio/functions/version/function-event-dialog/function-event-dialog.component.js
+++ b/src/nuclio/functions/version/function-event-dialog/function-event-dialog.component.js
@@ -147,7 +147,7 @@
          * @param {Event} event - JS event object
          */
         function applyChanges(event) {
-            ctrl.functionEventForm.$submitted = true;
+            ctrl.functionEventForm.$setSubmitted();
 
             if ((angular.isUndefined(event) || event.keyCode === EventHelperService.ENTER) &&
                 (ctrl.functionEventForm.$valid && ctrl.isFormChanged)) {

--- a/src/nuclio/functions/version/function-event-dialog/function-event-dialog.tpl.html
+++ b/src/nuclio/functions/version/function-event-dialog/function-event-dialog.tpl.html
@@ -12,8 +12,7 @@
                     {{ 'common:NAME' | i18next }}
                 </div>
                 <div class="field-content">
-                    <igz-validating-input-field class="nuclio-validating-input"
-                                                data-field-type="input"
+                    <igz-validating-input-field data-field-type="input"
                                                 data-input-name="displayName"
                                                 data-input-model-options="$ctrl.inputModelOptions"
                                                 data-input-value="$ctrl.workingCopy.spec.displayName"
@@ -42,8 +41,7 @@
                     {{ 'common:PATH' | i18next }}
                 </div>
                 <div class="field-content">
-                    <igz-validating-input-field class="nuclio-validating-input"
-                                                data-field-type="input"
+                    <igz-validating-input-field data-field-type="input"
                                                 data-input-name="path"
                                                 data-input-model-options="$ctrl.inputModelOptions"
                                                 data-input-value="$ctrl.workingCopy.spec.attributes.path"

--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
@@ -547,7 +547,7 @@
                 ctrl.testEventsForm.nameInput.$setValidity('text', true);
             }
 
-            ctrl.testEventsForm.$submitted = true;
+            ctrl.testEventsForm.$setSubmitted();
 
             if ((angular.isUndefined(event) || event.keyCode === EventHelperService.ENTER) &&
                 (ctrl.testEventsForm.$valid)) {

--- a/src/nuclio/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/functions/version/version-code/version-code.tpl.html
@@ -25,8 +25,7 @@
                             </div>
                             <div class="code-entry-col code-entry-handler-col">
                                 <div class="col-label handler">{{ 'functions:HANDLER' | i18next }}</div>
-                                <igz-validating-input-field class="nuclio-validating-input"
-                                                            data-field-type="input"
+                                <igz-validating-input-field data-field-type="input"
                                                             data-input-name="handler"
                                                             data-input-value="$ctrl.version.spec.handler"
                                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
@@ -86,8 +85,7 @@
                             </div>
                             <div class="code-entry-col code-entry-handler-col">
                                 <div class="col-label handler">{{ 'functions:HANDLER' | i18next }}</div>
-                                <igz-validating-input-field class="nuclio-validating-input"
-                                                            data-field-type="input"
+                                <igz-validating-input-field data-field-type="input"
                                                             data-input-name="handler"
                                                             data-input-value="$ctrl.version.spec.handler"
                                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
@@ -113,8 +111,7 @@
                                                     data-validation-is-required="true"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: mydockeruser/my-func:latest"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.image"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.image">
                         </igz-validating-input-field>
                     </div>
 
@@ -132,8 +129,7 @@
                                                     data-validation-is-required="true"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: https://v3io-webapi/users/iguazio/myfunction.zip"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.path"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.path">
                         </igz-validating-input-field>
                     </div>
 
@@ -151,8 +147,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_ACCESS_KEY' | i18next }}"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.headers['X-V3io-Session-Key']"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.headers['X-V3io-Session-Key']">
                         </igz-validating-input-field>
 
                         <div class="field-label">
@@ -167,8 +162,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: /nuclio-functions/myfunc"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.workDir"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.workDir">
                         </igz-validating-input-field>
                     </div>
 
@@ -186,8 +180,7 @@
                                                     data-validation-is-required="true"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: https://github.com/my-organization/my-repository"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.path"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.path">
                         </igz-validating-input-field>
                     </div>
 
@@ -205,8 +198,7 @@
                                                     data-validation-is-required="true"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: master"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.branch"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.branch">
                         </igz-validating-input-field>
                     </div>
 
@@ -223,8 +215,7 @@
                                                     data-form-object="$ctrl.versionCodeForm"
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_TOKEN' | i18next }}"
-                                                    data-update-data-callback="$ctrl.onChangeGithubToken(newData)"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-callback="$ctrl.onChangeGithubToken(newData)">
                         </igz-validating-input-field>
                     </div>
 
@@ -242,8 +233,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: /nuclio-functions/myfunc"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.workDir"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.workDir">
                         </igz-validating-input-field>
                     </div>
 
@@ -261,8 +251,7 @@
                                                     data-validation-is-required="true"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: my-s3-bucket"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.s3Bucket"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.s3Bucket">
                         </igz-validating-input-field>
 
                         <div class="field-label">
@@ -277,8 +266,7 @@
                                                     data-validation-is-required="true"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: my-dir/nuclio_funcs.zip"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.s3ItemKey"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.s3ItemKey">
                         </igz-validating-input-field>
 
                         <div class="field-label">
@@ -293,8 +281,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_ACCESS_KEY_ID' | i18next }}"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.s3AccessKeyId"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.s3AccessKeyId">
                         </igz-validating-input-field>
 
                         <div class="field-label">
@@ -309,8 +296,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_SECRET_ACCESS_KEY' | i18next }}"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.s3SecretAccessKey"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.s3SecretAccessKey">
                         </igz-validating-input-field>
 
                         <div class="field-label">
@@ -325,8 +311,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_SESSION_TOKEN' | i18next }}"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.s3SessionToken"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.s3SessionToken">
                         </igz-validating-input-field>
 
                         <div class="field-label">
@@ -341,8 +326,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: us-east-1"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.s3Region"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.s3Region">
                         </igz-validating-input-field>
 
                         <div class="field-label">
@@ -357,8 +341,7 @@
                                                     data-validation-is-required="false"
                                                     data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: /nuclio-functions/myfunc"
                                                     data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.workDir"
-                                                    class="nuclio-validating-input">
+                                                    data-update-data-field="spec.build.codeEntryAttributes.workDir">
                         </igz-validating-input-field>
                     </div>
                 </div>

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-annotations/version-configuration-annotations.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-annotations/version-configuration-annotations.component.js
@@ -12,10 +12,12 @@
         });
 
     function NclVersionConfigurationAnnotationsController($element, $i18next, $rootScope, $timeout, i18next, lodash,
-                                                          PreventDropdownCutOffService, ValidatingPatternsService) {
+                                                          FormValidationService, PreventDropdownCutOffService,
+                                                          ValidatingPatternsService) {
         var ctrl = this;
         var lng = i18next.language;
 
+        ctrl.annotationsForm = null;
         ctrl.igzScrollConfig = {
             maxElementsCount: 10,
             childrenSelector: '.table-body'
@@ -85,7 +87,7 @@
         }
 
         /**
-         * Linking method
+         * Post linking method
          */
         function postLink() {
 
@@ -166,6 +168,10 @@
 
                 newAnnotations[annotation.name] = annotation.value;
             });
+
+            // since uniqueness validation rule of some fields is dependent on the entire annotation list, then whenever
+            // the list is modified - the rest of the annotations need to be re-validated
+            FormValidationService.validateAllFields(ctrl.annotationsForm);
 
             $rootScope.$broadcast('change-state-deploy-button', {
                 component: 'annotation',

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.tpl.html
@@ -19,8 +19,7 @@
                 </div>
                 <div class="timeout-values">
                     <div class="inputs">
-                        <igz-validating-input-field class="nuclio-validating-input"
-                                                    data-field-type="input"
+                        <igz-validating-input-field data-field-type="input"
                                                     data-input-name="min"
                                                     data-input-value="$ctrl.timeout.min"
                                                     data-is-focused="false"
@@ -33,8 +32,7 @@
                                                     data-placeholder-text="{{ 'functions:MIN' | i18next }}...">
                         </igz-validating-input-field>
                         <div class="values-label">{{ 'functions:MIN' | i18next }}</div>
-                        <igz-validating-input-field class="nuclio-validating-input"
-                                                    data-field-type="input"
+                        <igz-validating-input-field data-field-type="input"
                                                     data-input-name="sec"
                                                     data-input-value="$ctrl.timeout.sec"
                                                     data-is-focused="false"
@@ -54,8 +52,7 @@
         <div class="row">
             <div class="description-block">
                 <div class="label">{{ 'common:DESCRIPTION' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="description"
                                             data-input-value="$ctrl.version.spec.description"
                                             data-is-focused="false"
@@ -69,8 +66,7 @@
         <div class="row">
             <div class="account-block">
                 <div class="label">{{ 'functions:SERVICE_ACCOUNT' | i18next }}</div>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="serviceAccount"
                                             data-input-value="$ctrl.version.spec.serviceAccount"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
@@ -95,8 +91,7 @@
                 <div class="logger-input"
                      data-ng-if="$ctrl.isDemoMode()">
                     <span class="label">{{ 'functions:LOGGER_DESTINATION' | i18next }}</span>
-                    <igz-validating-input-field class="nuclio-validating-input"
-                                                data-field-type="input"
+                    <igz-validating-input-field data-field-type="input"
                                                 data-input-name="arguments"
                                                 data-input-value="$ctrl.version.spec.loggerSinks[0].sink"
                                                 data-update-data-callback="$ctrl.inputValueCallback(newData, field)"

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build-dialog/version-configuration-build-dialog.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build-dialog/version-configuration-build-dialog.tpl.html
@@ -12,8 +12,7 @@
             <div class="field-label">
                 {{ 'functions:REMOTE_PATH' | i18next }}
             </div>
-            <igz-validating-input-field class="nuclio-validating-input"
-                                        data-field-type="input"
+            <igz-validating-input-field data-field-type="input"
                                         data-is-focused="true"
                                         data-placeholder-text="{{ 'common:PLACEHOLDER.ENTER_PATH' | i18next }}">
             </igz-validating-input-field>

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
@@ -35,7 +35,7 @@
                                                 data-validation-max-length="255"
                                                 data-validation-pattern="$ctrl.imageNameValidationPattern"
                                                 data-is-disabled="$ctrl.disabled"
-                                                class="nuclio-validating-input flex-auto">
+                                                class="flex-auto">
                     </igz-validating-input-field>
                 </div>
             </div>
@@ -55,8 +55,7 @@
                                             data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_BASE_IMAGE' | i18next }}"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
                                             data-update-data-field="spec.build.baseImage"
-                                            data-is-disabled="$ctrl.disabled"
-                                            class="nuclio-validating-input">
+                                            data-is-disabled="$ctrl.disabled">
                 </igz-validating-input-field>
             </div>
             <div class="igz-col-50 build-field build-onbuild-image-field">
@@ -75,8 +74,7 @@
                                             data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_ONBUILD_IMAGE' | i18next }}"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
                                             data-update-data-field="spec.build.onbuildImage"
-                                            data-is-disabled="$ctrl.disabled"
-                                            class="nuclio-validating-input">
+                                            data-is-disabled="$ctrl.disabled">
                 </igz-validating-input-field>
             </div>
             <div class="igz-col-100 build-field">
@@ -96,7 +94,7 @@
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
                                             data-update-data-field="commands"
                                             data-is-disabled="$ctrl.disabled"
-                                            class="nuclio-validating-input build-textarea-input build-commands-input">
+                                            class="build-textarea-input build-commands-input">
                 </igz-validating-input-field>
             </div>
             <div class="igz-col-100 build-field">
@@ -130,7 +128,7 @@
                                             data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_REPOSITORY_ON_EACH_LINE' | i18next }}"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
                                             data-update-data-field="runtimeAttributes.repositories"
-                                            class="nuclio-validating-input build-textarea-input"
+                                            class="build-textarea-input"
                                             data-is-disabled="$ctrl.disabled">
                 </igz-validating-input-field>
             </div>
@@ -145,7 +143,7 @@
                                             data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_DEPENDENCY_ON_EACH_LINE' | i18next }}"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
                                             data-update-data-field="dependencies"
-                                            class="nuclio-validating-input build-textarea-input"
+                                            class="build-textarea-input"
                                             data-is-disabled="$ctrl.disabled">
                 </igz-validating-input-field>
             </div>

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.component.js
@@ -12,11 +12,13 @@
         });
 
     function NclVersionConfigurationEnvironmentVariablesController($element, $i18next, $rootScope, $timeout, i18next,
-                                                                   lodash, PreventDropdownCutOffService,
+                                                                   lodash, FormValidationService,
+                                                                   PreventDropdownCutOffService,
                                                                    ValidatingPatternsService) {
         var ctrl = this;
         var lng = i18next.language;
 
+        ctrl.environmentVariablesForm = null;
         ctrl.igzScrollConfig = {
             maxElementsCount: 10,
             childrenSelector: '.table-body'
@@ -47,6 +49,7 @@
                 }
             ]
         };
+        ctrl.variables = [];
         ctrl.scrollConfig = {
             axis: 'y',
             advanced: {
@@ -122,7 +125,12 @@
                         }
                     });
 
-                    $rootScope.$broadcast('change-state-deploy-button', {component: 'variable', isDisabled: true});
+                    ctrl.environmentVariablesForm.$setPristine();
+
+                    $rootScope.$broadcast('change-state-deploy-button', {
+                        component: 'variable',
+                        isDisabled: true
+                    });
                     event.stopPropagation();
                 }
             }, 50);
@@ -181,7 +189,7 @@
         //
 
         /**
-         * Updates function`s variables
+         * Updates function's variables
          */
         function updateVariables() {
             var isFormValid = true;
@@ -193,7 +201,10 @@
                 return lodash.omit(variable, 'ui');
             });
 
-            $rootScope.$broadcast('update-patterns-validity', ['key', 'value']);
+            // since uniqueness validation rule of some fields is dependent on the entire environment variable list,
+            // then whenever the list is modified - the rest of the environment variables need to be re-validated
+            FormValidationService.validateAllFields(ctrl.environmentVariablesForm);
+
             $rootScope.$broadcast('change-state-deploy-button', {
                 component: 'variable',
                 isDisabled: !isFormValid

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.component.js
@@ -12,8 +12,8 @@
         });
 
     function NclVersionConfigurationLabelsController($element, $i18next, $rootScope, $timeout, i18next, lodash,
-                                                     PreventDropdownCutOffService, ValidatingPatternsService,
-                                                     VersionHelperService) {
+                                                     FormValidationService, PreventDropdownCutOffService,
+                                                     ValidatingPatternsService, VersionHelperService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -21,6 +21,7 @@
             maxElementsCount: 10,
             childrenSelector: '.table-body'
         };
+        ctrl.labelsForm = null;
         ctrl.scrollConfig = {
             axis: 'y',
             advanced: {
@@ -190,6 +191,10 @@
 
                 newLabels[label.name] = label.value;
             });
+
+            // since uniqueness validation rule of some fields is dependent on the entire label list, then whenever
+            // the list is modified - the rest of the labels need to be re-validated
+            FormValidationService.validateAllFields(ctrl.labelsForm);
 
             $rootScope.$broadcast('change-state-deploy-button', {
                 component: 'label',

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-runtime-attributes/version-configuration-runtime-attributes.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-runtime-attributes/version-configuration-runtime-attributes.tpl.html
@@ -13,8 +13,7 @@
             <div class="arguments-input"
                  data-ng-if="$ctrl.version.spec.runtime === 'shell'">
                 <span class="label">{{ 'common:ARGUMENTS' | i18next }}</span>
-                <igz-validating-input-field class="nuclio-validating-input"
-                                            data-field-type="input"
+                <igz-validating-input-field data-field-type="input"
                                             data-input-name="arguments"
                                             data-input-value="$ctrl.runtimeAttributes.arguments"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
@@ -36,7 +35,7 @@
                                             data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_OPTION_ON_EACH_LINE' | i18next }}"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
                                             data-update-data-field="jvmOptions"
-                                            class="nuclio-validating-input build-command-field java-attribute">
+                                            class="build-command-field java-attribute">
                 </igz-validating-input-field>
             </div>
         </div>

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-volumes/version-configuration-volumes.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-volumes/version-configuration-volumes.component.js
@@ -11,13 +11,15 @@
             controller: NclVersionConfigurationVolumesController
         });
 
-    function NclVersionConfigurationVolumesController($rootScope, $scope, $timeout, $i18next, i18next, lodash, DialogsService,
+    function NclVersionConfigurationVolumesController($rootScope, $scope, $timeout, $i18next, i18next, lodash,
+                                                      DialogsService, FormValidationService,
                                                       FunctionsService, ValidatingPatternsService) {
         var ctrl = this;
         var lng = i18next.language;
 
         ctrl.isCreateModeActive = false;
         ctrl.volumes = [];
+        ctrl.volumesForm = null;
         ctrl.igzScrollConfig = {
             maxElementsCount: 5,
             childrenSelector: '.ncl-collapsing-row'
@@ -119,6 +121,8 @@
                         }
                     );
 
+                    ctrl.volumesForm.$setPristine();
+
                     event.stopPropagation();
                     $rootScope.$broadcast('change-state-deploy-button', { component: 'volume', isDisabled: true });
                 }
@@ -169,7 +173,7 @@
          */
         function checkValidation() {
             if (lodash.some(ctrl.volumes, ['ui.isFormValid', false])) {
-                $rootScope.$broadcast('update-patterns-validity', ['itemName', 'itemPath']);
+                FormValidationService.validateAllFields(ctrl.volumesForm);
             }
         }
 
@@ -181,6 +185,8 @@
         function deleteHandler(selectedItem, index) {
             ctrl.volumes.splice(index, 1);
 
+            // since uniqueness validation rule of some fields is dependent on the entire volume list, whenever a volume
+            // is removed, the rest of the volumes needs to be re-validated
             checkValidation();
 
             var workingCopy = lodash.map(ctrl.volumes, function (volume) {
@@ -222,6 +228,8 @@
                     volume: selectedItem.volume
                 };
 
+                // since uniqueness validation rule of some fields is dependent on the entire volume list, whenever a
+                // volume is updated, the rest of the volumes needs to be re-validated
                 checkValidation();
 
                 lodash.forEach(workingCopy, function (volume) {


### PR DESCRIPTION
- `igzValidatingInputField`: Remove `on-blur` attribute which was redundant (there is already an `item-blur-callback` attribute).
- Nuclio function triggers:
  - All kinds: add a red asterisk to mark mandatory fields.
  - For HTTP annotations and Cron event handlers: [bugfix] Key field was not mandatory, now it is.
- `FormValidationService`: add `validateAllFields` method to validate all immediate and nested fields of a form (`ngForm`).
- Use `ngForm.$setSubmitted()` and `ngForm.$setPristine()` instead of `ngForm.$submitted = true/false`.
- Nuclio: Remove unnecessary border color change on hovering input fields.
- Better use `jQuery` where it is already there, instead of DOM APIs (offset position, dimensions, $document, ...).