### PR TITLE
Cleanup [General] Remove unnecessary `ng-cloak` CSS rule

### DIFF
--- a/src/igz_controls/less/general-rules.less
+++ b/src/igz_controls/less/general-rules.less
@@ -143,8 +143,3 @@ ul, ol {
     left: 0;
     background-color: @modal-backgrop-bg-color;
 }
-
-[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
-    display: none !important;
-}
-


### PR DESCRIPTION
This rule is provided by angular.js (or angular.min.js) as part of AngularJS package.

It's included in https://github.com/angular/angular.js/blob/master/css/angular.css, which is taken in build process here: https://github.com/angular/angular.js/blob/9ae51d751b3803d610652687b6a63f98f825a592/lib/grunt/utils.js#L113 to generate this in the end result angular.js file:
```js
!window.angular.$$csp().noInlineStyle && window.angular.element(document.head).prepend('<style type="text/css">@charset "UTF-8";[ng\\:cloak],[ng-cloak],[data-ng-cloak],[x-ng-cloak],.ng-cloak,.x-ng-cloak,.ng-hide:not(.ng-hide-animate){display:none !important;}ng\\:form{display:block;}.ng-animate-shim{visibility:hidden;}.ng-anchor{position:absolute;}</style>');
```

As you can see here, the AngularJS package properly injects this `<style>` in the `<head>` of the document:
![image](https://user-images.githubusercontent.com/13918850/80865521-b2bbfe00-8c92-11ea-9be8-853b02d93b09.png)