### PR TITLE
Impl [igzValidatePasswordConfirmation] Move component to this repo

### DIFF
--- a/src/igz_controls/directives/validate-password-confirmation.directive.js
+++ b/src/igz_controls/directives/validate-password-confirmation.directive.js
@@ -1,0 +1,55 @@
+(function () {
+    'use strict';
+
+    angular.module('iguazio.app')
+        .directive('igzValidatePasswordConfirmation', igzValidatePasswordConfirmation);
+
+    function igzValidatePasswordConfirmation(lodash) {
+        return {
+            restrict: 'A',
+            require: 'ngModel',
+            scope: {
+                compareVal: '=igzValidatePasswordConfirmation'
+            },
+            link: link
+        };
+
+        function link(scope, element, attributes, ngModel) {
+            activate();
+
+            //
+            // Private methods
+            //
+
+            /**
+             * Constructor
+             */
+            function activate() {
+                initValidator();
+            }
+
+            /**
+             * Method to add validators
+             */
+            function initValidator() {
+                if (angular.isDefined(scope.compareVal)) {
+                    ngModel.$validators.validatePasswordConfirmation = isValueValid;
+
+                    scope.$watch('compareVal', function () {
+                        ngModel.$validate();
+                    });
+                }
+            }
+
+            /**
+             * Method checks if passed value is valid
+             * @param {string} value - current changed value
+             * @returns {boolean} return true if value is valid
+             */
+            function isValueValid(value) {
+                return lodash.isEmpty(value) || (value === scope.compareVal);
+            }
+        }
+    }
+}());
+


### PR DESCRIPTION
This directive is being used by `igzValidatingInputField` component which resides in this repo, then it only make sense to also have `igzValidatePasswordConfirmation` here along with it.