### PR TITLE
Fix [igzValidatingInputField] Cannot share validation rules

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.js
@@ -114,7 +114,7 @@
                 validationIsRequired: '<?',
                 validationMaxLength: '@?',
                 validationPattern: '<?',
-                validationRules: '<?'
+                validationRules: '<*?'
             },
             templateUrl: 'igz_controls/components/validating-input-field/validating-input-field.tpl.html',
             controller: IgzValidatingInputFieldController
@@ -272,7 +272,7 @@
             }
 
             if (angular.isDefined(changes.validationRules)) {
-                ctrl.validationRules = lodash.defaultTo(changes.validationRules.currentValue, []);
+                ctrl.validationRules = angular.copy(lodash.defaultTo(changes.validationRules.currentValue, []));
             }
         }
 
@@ -351,7 +351,7 @@
 
         /**
          * Loses focus from input field.
-         * @param {Event} event - the `blur` event object.
+         * @param {FocusEvent} event - the `blur` event object.
          */
         function onBlur(event) {
             if (ctrl.preventInputBlur) {


### PR DESCRIPTION
If the same array is passed to `validationRules` attribute of different instances of `igzValidatingInputField` - it breaks.
One of the instances sets rules valid/invalid, and it is reflected in the other instance, too.

In addition, changed `validationRules` attribute from `<` to `<*` so added/removed validation rules are detected without changing to a different array.