### PR TITLE
Impl [igzNumberInput] Refactor: improvements, cleanup, docs

### DIFF
--- a/src/igz_controls/components/number-input/number-input.component.spec.js
+++ b/src/igz_controls/components/number-input/number-input.component.spec.js
@@ -191,7 +191,7 @@ describe('igzNumberInput component:', function () {
         });
     });
 
-    describe('checkInvalidation(): ', function () {
+    describe('isValid(): ', function () {
         beforeEach(function () {
             ctrl.formObject = {
                 'input_name': {
@@ -205,7 +205,7 @@ describe('igzNumberInput component:', function () {
             spyOn(ctrl, 'isShowFieldInvalidState').and.returnValue(true);
 
             ctrl.currentValue = '1';
-            ctrl.checkInvalidation();
+            ctrl.isValid();
 
             expect(ctrl.isShowFieldInvalidState).toHaveBeenCalled();
         });

--- a/src/igz_controls/components/number-input/number-input.less
+++ b/src/igz_controls/components/number-input/number-input.less
@@ -25,7 +25,7 @@
             outline: none;
         }
 
-        &:focus, &.focused {
+        &:focus-within, &.focused {
             outline: 0;
             border: @number-input-not-disabled-hover-focus-border;
         }
@@ -119,6 +119,7 @@
             cursor: pointer;
             display: block;
             line-height: 11px;
+            outline: 0;
 
             &:hover {
                 color: @number-input-arrow-block-icon-hover-color;

--- a/src/igz_controls/components/number-input/number-input.tpl.html
+++ b/src/igz_controls/components/number-input/number-input.tpl.html
@@ -1,9 +1,11 @@
-<div class="igz-number-input" tabindex="0"
-     data-ng-class="[{'invalid': $ctrl.checkInvalidation()},
-                    {'pristine': !$ctrl.numberInputChanged},
-                    {'disabled': $ctrl.isDisabled},
-                    {'focused': $ctrl.inputFocused},
-                    {'submitted': $ctrl.formObject.$submitted}]">
+<div class="igz-number-input"
+     data-ng-class="{
+         disabled: $ctrl.isDisabled,
+         focused: $ctrl.inputFocused,
+         invalid: $ctrl.isValid(),
+         pristine: !$ctrl.numberInputChanged,
+         submitted: $ctrl.formObject.$submitted
+     }">
     <div class="additional-left-block flex-none">
         <span class="prefix-unit" data-ng-show="$ctrl.isShownUnit($ctrl.prefixUnit)">{{$ctrl.prefixUnit}}</span>
     </div>
@@ -20,11 +22,11 @@
            size="1"
            placeholder="{{$ctrl.placeholder}}"
            data-precision="{{$ctrl.precision}}"
-           data-ng-focus="$ctrl.setFocus()"
-           data-ng-blur="$ctrl.onBlurInput()"
-           data-ng-change="$ctrl.onChangeInput()"
+           data-ng-focus="$ctrl.handleInputFocus($event)"
+           data-ng-blur="$ctrl.handleInputBlur($event)"
+           data-ng-change="$ctrl.handleInputChange()"
            data-ng-disabled="$ctrl.isDisabled"
-           data-ng-required="$ctrl.validationIsRequired === 'true'"
+           data-ng-required="$ctrl.validationIsRequired"
            data-igz-validate-elevation
            data-compare-val="$ctrl.validationValue"
            data-compare-val-unit="$ctrl.validationValueUnit.power"
@@ -32,13 +34,13 @@
 
     <span class="suffix-unit flex-none"
           data-ng-show="$ctrl.isShownUnit($ctrl.suffixUnit)"
-          data-ng-click="$ctrl.onUnitClick()">
+          data-ng-click="$ctrl.handleSuffixClick($event)">
         {{$ctrl.suffixUnit}}
     </span>
 
     <div class="arrow-block flex-none">
-        <span class="igz-icon-dropup" data-ng-click="$ctrl.isDisabled || $ctrl.increaseValue()"></span>
-        <span class="igz-icon-dropdown" data-ng-click="$ctrl.isDisabled || $ctrl.decreaseValue()"></span>
+        <span tabindex="-1" class="igz-icon-dropup" data-ng-click="$ctrl.isDisabled || $ctrl.increaseValue()"></span>
+        <span tabindex="-1" class="igz-icon-dropdown" data-ng-click="$ctrl.isDisabled || $ctrl.decreaseValue()"></span>
     </div>
 </div>
 

--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.js
@@ -29,7 +29,8 @@
      * @param {Object} [inputModelOptions] - A `ngModelOptions` object to forward to `ng-model-options` attribute of
      *     the HTML `<input>` or `<textarea>` element. Some options may be ignored/overridden by this component to make
      *     some of its features work properly.
-     * @param {string} inputName - The name of the filed, will be forwarded to the `name` attribute of the HTML element.
+     * @param {string} inputName - The name of the filed, will be forwarded to the `name` attribute of the HTML
+     *     `<input>` element.
      * @param {*} inputValue - The initial value of the field. This is a one-way binding that is watched for changes.
      * @param {function} [itemBlurCallback] - A callback function for `blur` event. Invoked with `inputValue` and
      *     `inputName` when the field loses focus. Note that when `is-data-revert` attribute is `false` and blur event

--- a/src/igz_controls/directives/validate-elevation.directive.js
+++ b/src/igz_controls/directives/validate-elevation.directive.js
@@ -1,0 +1,46 @@
+(function () {
+    'use strict';
+
+    angular.module('iguazio.dashboard-controls')
+        .directive('igzValidateElevation', igzValidateElevation);
+
+    function igzValidateElevation(lodash) {
+        return {
+            restrict: 'A',
+            require: 'ngModel',
+            scope: {
+                compareVal: '=',
+                compareValUnit: '=',
+                currentValUnit: '='
+            },
+            link: link
+        };
+
+        function link(scope, element, attributes, ngModel) {
+            activate();
+
+            function activate() {
+                if (angular.isDefined(scope.compareVal)) {
+                    ngModel.$validators.validateElevation = function (modelValue) {
+                        return lodash.isNil(modelValue) || lodash.isNil(scope.compareVal) ||
+                            calcValue(modelValue, scope.currentValUnit) <= calcValue(scope.compareVal, scope.compareValUnit);
+
+                        function calcValue(value, unit) {
+                            return (Number(unit) || 1) * Number(value);
+                        }
+                    };
+
+                    scope.$watch('compareVal', function () {
+                        ngModel.$validate();
+                    });
+
+                    if (angular.isDefined(scope.compareValUnit) && angular.isDefined(scope.currentValUnit)) {
+                        scope.$watchGroup(['compareValUnit', 'currentValUnit'], function () {
+                            ngModel.$validate();
+                        });
+                    }
+                }
+            }
+        }
+    }
+}());


### PR DESCRIPTION
- Do not have double focus on this component on sequential keyboard navigation (via the TAB key).
- `itemBlurCallback`: added `event` and `inputValue` arguments on invocation.
- `itemFocusCallback`: added `event` argument on invocation.
- Added JSDoc.
- Moved `igzValidateElevation` directive from Iguazio dashboard repo to this repo because `igzNumberInput` uses it.