### PR TITLE
Fix [igzActionItemMore] Click area is icon only instead of item

### DIFF
--- a/src/igz_controls/components/action-item/action-item-more/action-item-more.tpl.html
+++ b/src/igz_controls/components/action-item/action-item-more/action-item-more.tpl.html
@@ -1,12 +1,12 @@
 <div class="igz-action-item"
-     data-ng-class="{'subtemplate-show': $ctrl.isDropdownShown}">
+     data-ng-class="{'subtemplate-show': $ctrl.isDropdownShown}"
+     data-ng-click="$ctrl.toggleTemplate()">
 
     <div data-uib-tooltip="{{ 'common:MORE_OPTIONS' | i18next }}"
          data-tooltip-popup-delay="1000"
          data-tooltip-placement="bottom">
 
-        <div class="action-icon igz-icon-context-menu"
-             data-ng-click="$ctrl.toggleTemplate()"></div>
+        <div class="action-icon igz-icon-context-menu"></div>
     </div>
 
     <div class="item-dropdown-menu igz-component" data-ng-show="$ctrl.isDropdownShown">


### PR DESCRIPTION
Before:
<img width="103" alt="more-icon_click-area_before" src="https://user-images.githubusercontent.com/13918850/82231076-4ea56500-9935-11ea-97f9-87cb78b6ec89.png">

After:
<img width="103" alt="more-icon_click-area_after" src="https://user-images.githubusercontent.com/13918850/82231086-5238ec00-9935-11ea-8426-0842e5d5bafb.png">
