### PR TITLE
Fix [Nuclio] Function "View YAML": no syntax highlighting

### DIFF
--- a/src/nuclio/common/components/function-config-dialog/function-config-dialog.tpl.html
+++ b/src/nuclio/common/components/function-config-dialog/function-config-dialog.tpl.html
@@ -9,7 +9,7 @@
                     data-function-source-code="$ctrl.sourceCode"
                     data-mini-monaco="false"
                     data-selected-theme="$ctrl.editorTheme"
-                    data-language="yaml"
+                    data-language="'yaml'"
                     data-read-only="true">
         </ncl-monaco>
     </div>

--- a/src/nuclio/functions/version/function-event-dialog/function-event-dialog.tpl.html
+++ b/src/nuclio/functions/version/function-event-dialog/function-event-dialog.tpl.html
@@ -72,7 +72,7 @@
                      class="field-content code-edit-section">
                     <ncl-monaco data-function-source-code="$ctrl.workingCopy.spec.body"
                                 data-selected-theme="$ctrl.bodyTheme"
-                                data-language="json"
+                                data-language="'json'"
                                 data-mini-monaco="true"
                                 data-on-change-source-code-callback="$ctrl.onChangeSourceCode(sourceCode)"
                                 data-read-only="false">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/13918850/82437351-e757f400-9a9f-11ea-8b61-09244bc00e60.png)

After:
![image](https://user-images.githubusercontent.com/13918850/82437356-ea52e480-9a9f-11ea-967e-669de27bab68.png)
