### PR TITLE
Fix [igzValidatingInputField] Field not validated on change

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.js
@@ -401,8 +401,8 @@
          * Updates outer model value on inner model value change.
          */
         function onChange() {
+            ngModel.$validate();
             if (ctrl.isDataRevert) {
-                ngModel.$validate();
                 if (ngModel.$valid) {
                     // update `lastValidValue` to later use it on `blur` event in case `is-data-revert` attribute is
                     // `true` and the input field is invalid (so the input field could be reverted to the last valid


### PR DESCRIPTION
The handler function passed to `updateDataCallback` did not have the updated value for `$valid` and `$invalid` flags of the input.
Hence the corresponding `ngForm` validity was not up-to-date as well.