### PR TITLE
Fix [igzValidatingInputField] Textarea: cleared on maxlength err

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
@@ -79,6 +79,7 @@
                   placeholder="{{$ctrl.placeholderText}}"
                   tabindex="{{$ctrl.tabindex}}"
                   data-ng-model="$ctrl.data"
+                  data-ng-model-options="$ctrl.inputModelOptions"
                   data-ng-required="$ctrl.validationIsRequired"
                   data-ng-maxlength="$ctrl.validationMaxLength"
                   data-ng-pattern="$ctrl.validationPattern"


### PR DESCRIPTION
When the user enters input with lengths bigger than what is set in `validationMaxLength` - the input clears automatically instead of remaining and just rendering the field invalid.