### PR TITLE
Fix [Nuclio] V3IO-stream trigger: Access Key populated improperly

### DIFF
--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -499,7 +499,7 @@
                                 label: $i18next.t('functions:ACCESS_KEY', { lng: lng }),
                                 type: 'input',
                                 fieldType: 'password',
-                                path: 'attributes.password',
+                                path: 'password',
                                 placeholder: $i18next.t('functions:PLACEHOLDER.ENTER_ACCESS_KEY', { lng: lng }),
                                 allowEmpty: false,
                                 autocomplete: 'new-password'


### PR DESCRIPTION
Access Key field was bound to `attributes.password` instead of `password` inside the trigger model.