### PR TITLE
Impl [Nuclio] Triggers: Kafka: Brokers & Topics: no empty lists

### DIFF
--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -163,9 +163,9 @@
 
                 ctrl.topics = lodash.chain(ctrl.item.attributes.topics)
                     .defaultTo([])
-                    .map(function (value, key) {
+                    .map(function (value, index) {
                         return {
-                            name: key,
+                            name: index,
                             value: value,
                             ui: {
                                 editModeActive: false,
@@ -178,9 +178,9 @@
 
                 ctrl.brokers = lodash.chain(ctrl.item.attributes.brokers)
                     .defaultTo([])
-                    .map(function (value, key) {
+                    .map(function (value, index) {
                         return {
-                            name: key,
+                            name: index,
                             value: value,
                             ui: {
                                 editModeActive: false,
@@ -743,9 +743,25 @@
                 } else if (field.name === 'subscriptions') {
                     ctrl.subscriptions = [];
                 } else if (field.name === 'kafka-topics') {
-                    ctrl.topics = [];
+                    ctrl.topics = [{
+                        name: '',
+                        value: '',
+                        ui: {
+                            editModeActive: true,
+                            isFormValid: false,
+                            name: 'topic'
+                        }
+                    }];
                 } else if (field.name === 'kafka-brokers') {
-                    ctrl.brokers = [];
+                    ctrl.brokers = [{
+                        name: '',
+                        value: '',
+                        ui: {
+                            editModeActive: true,
+                            isFormValid: false,
+                            name: 'broker'
+                        }
+                    }];
                 } else if (field.name === 'annotations') {
                     ctrl.annotations = [];
                 }
@@ -1042,9 +1058,7 @@
          * Updates topics fields
          */
         function updateTopics() {
-            var newTopics = lodash.map(ctrl.topics, function (topic) {
-                return topic.value;
-            });
+            var newTopics = lodash.map(ctrl.topics, 'value');
 
             lodash.set(ctrl.item, 'attributes.topics', newTopics);
         }
@@ -1053,9 +1067,7 @@
          * Updates Brokers fields
          */
         function updateBrokers() {
-            var newBrokers = lodash.map(ctrl.brokers, function (broker) {
-                return broker.value;
-            });
+            var newBrokers = lodash.map(ctrl.brokers, 'value');
 
             lodash.set(ctrl.item, 'attributes.brokers', newBrokers);
         }

--- a/src/nuclio/common/components/edit-item/edit-item.tpl.html
+++ b/src/nuclio/common/components/edit-item/edit-item.tpl.html
@@ -182,7 +182,7 @@
             </div>
 
             <div class="igz-col-45 attribute-field brokers-wrapper" data-ng-if="$ctrl.isKafkaTrigger()">
-                <div class="field-label">{{ 'functions:BROKERS' | i18next }}</div>
+                <div class="field-label asterisk">{{ 'functions:BROKERS' | i18next }}</div>
                 <div>
                     <div class="table-body" data-ng-repeat="broker in $ctrl.brokers">
                         <ncl-key-value-input class="new-label-input"
@@ -191,6 +191,7 @@
                                              data-row-data="broker"
                                              data-use-type="false"
                                              data-submit-on-fly="true"
+                                             data-no-delete="$ctrl.brokers.length <= 1"
                                              data-item-index="$index"
                                              data-only-value-input="true"
                                              data-action-handler-callback="$ctrl.handleBrokerAction(actionType, index)"
@@ -206,7 +207,7 @@
             </div>
 
             <div class="igz-col-45 attribute-field topics-wrapper" data-ng-if="$ctrl.isKafkaTrigger()">
-                <div class="field-label">{{ 'functions:TOPICS' | i18next }}</div>
+                <div class="field-label asterisk">{{ 'functions:TOPICS' | i18next }}</div>
                 <div>
                     <div class="table-body" data-ng-repeat="topic in $ctrl.topics">
                         <ncl-key-value-input class="new-label-input"
@@ -215,6 +216,7 @@
                                              data-row-data="topic"
                                              data-use-type="false"
                                              data-submit-on-fly="true"
+                                             data-no-delete="$ctrl.topics.length <= 1"
                                              data-item-index="$index"
                                              data-only-value-input="true"
                                              data-action-handler-callback="$ctrl.handleTopicAction(actionType, index)"

--- a/src/nuclio/common/components/key-value-input/key-value-input.component.js
+++ b/src/nuclio/common/components/key-value-input/key-value-input.component.js
@@ -20,6 +20,7 @@
                 keyTooltip: '<?',
                 keyValidationPattern: '<?',
                 listClass: '@?',
+                noDelete: '<?',
                 onlyValueInput: '<?',
                 rowData: '<',
                 submitOnFly: '<?',
@@ -48,6 +49,7 @@
         ctrl.$onInit = onInit;
         ctrl.$postLink = postLink;
         ctrl.$onDestroy = onDestroy;
+        ctrl.$onChanges = onChanges;
 
         ctrl.onEditInput = onEditInput;
         ctrl.getInputValue = getInputValue;
@@ -61,7 +63,6 @@
         ctrl.onFireAction = onFireAction;
         ctrl.onKeyChanged = onKeyChanged;
         ctrl.onTypeChanged = onTypeChanged;
-        ctrl.showDotMenu = showDotMenu;
 
         //
         // Hook methods
@@ -119,6 +120,19 @@
                     component: ctrl.data.ui.name,
                     isDisabled: ctrl.keyValueInputForm.$invalid
                 });
+            }
+        }
+
+        /**
+         * On changes hook method
+         * @param {Object} changes
+         */
+        function onChanges(changes) {
+            if (lodash.has(changes, 'noDelete')) {
+                lodash.defaults(ctrl, {
+                    noDelete: false
+                });
+                ctrl.actions = initActions();
             }
         }
 
@@ -308,13 +322,6 @@
             $document.on('keypress', saveChanges);
         }
 
-        /**
-         * Checks if show dot menu
-         */
-        function showDotMenu() {
-            return ctrl.actions.length > 1;
-        }
-
         //
         // Private method
         //
@@ -371,7 +378,7 @@
          * @returns {Array.<Object>}
          */
         function initActions() {
-            return [
+            return ctrl.noDelete ? [] : [
                 {
                     label: $i18next.t('common:DELETE', {lng: lng}),
                     id: 'delete',

--- a/src/nuclio/common/components/key-value-input/key-value-input.tpl.html
+++ b/src/nuclio/common/components/key-value-input/key-value-input.tpl.html
@@ -138,13 +138,13 @@
                 </igz-validating-input-field>
             </div>
         </div>
-        <div class="three-dot-menu" data-ng-if="::$ctrl.showDotMenu() && !$ctrl.isDisabled">
+        <div class="three-dot-menu" data-ng-if="$ctrl.actions.length > 1 && !$ctrl.isDisabled">
             <igz-action-menu data-actions="$ctrl.actions"
                              data-on-fire-action="$ctrl.onFireAction"
                              data-list-class="$ctrl.listClass">
             </igz-action-menu>
         </div>
-        <div class="igz-action-panel" data-ng-if="::!$ctrl.showDotMenu() && !$ctrl.isDisabled">
+        <div class="igz-action-panel" data-ng-if="$ctrl.actions.length === 1 && !$ctrl.isDisabled">
             <div class="actions-list">
                 <div class="igz-action-item"
                      data-ng-click="$ctrl.onClickAction($ctrl.actions[0])">


### PR DESCRIPTION
Currently enforced for new trigger only.
Might not work for existing trigger with 0 brokers/topics.

- When creating a new trigger, it starts with one empty broker and one empty topic.
- No delete action when there is only one item on the list

![image](https://user-images.githubusercontent.com/13918850/87555304-f1702a80-c6bd-11ea-9c66-8aff160ed535.png)
