### PR TITLE
Fix [Nuclio] Triggers: trigger not collapsing on click bg below

### DIFF
--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -870,7 +870,7 @@
                 '.actions-menu',
                 '.single-action',
                 '.ngdialog',
-                '.mCustomScrollBox'
+                '.mCSB_draggerContainer'
             ];
 
             return lodash.every(elementsForValidation, function (element) {


### PR DESCRIPTION
When clicking on the grey background below the trigger list, the expanded trigger is not collapsed:
![image](https://user-images.githubusercontent.com/13918850/89993960-21482900-dc90-11ea-9c3b-7df660d7229d.png)

Before:
![nuclio_triggers_collapse-bug_before](https://user-images.githubusercontent.com/13918850/89993975-27d6a080-dc90-11ea-976b-dffcc0ff7ca6.gif)

After:
![nuclio_triggers_collapse-bug_after](https://user-images.githubusercontent.com/13918850/89993982-2b6a2780-dc90-11ea-8517-afb19ff03560.gif)
