### PR TITLE
Fix [igzValidatingInputField] Popup: blocked click below field

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.less
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.less
@@ -170,7 +170,8 @@
         z-index: 4;
 
         .validation-pop-up {
-            position: relative;
+            position: absolute;
+            width: 260px;
             border-radius: 3px;
             opacity: 1;
             box-shadow: @validation-pop-up-box-shadow;
@@ -181,12 +182,12 @@
                 opacity: 0;
             }
 
-            &.ng-hide-remove {
+            &.ng-hide-remove, &.ng-hide-add {
                 transition: opacity 0.1s ease-in;
             }
 
             &.validation-pop-up-top {
-                top: calc(-100% - 38px);
+                bottom: 38px;
             }
 
             &.validation-pop-up-bottom {

--- a/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.tpl.html
@@ -4,6 +4,7 @@
         <div class="validation-icon"
              data-ng-if="$ctrl.validationRules.length > 0 && !$ctrl.readOnly && ($ctrl.inputFocused || $ctrl.isFieldInvalid())"
              data-ng-mousedown="$ctrl.preventInputBlur = true"
+             data-ng-click="$ctrl.toggleValidationPopUp()"
              data-ng-class="[$ctrl.inputFocused ? '' : $ctrl.bordersModeClass, {
                  'igz-icon-verify-info': $ctrl.inputIsTouched && $ctrl.data === '',
                  'igz-icon-verify-error': $ctrl.hasInvalidRule() && $ctrl.data !== '',
@@ -53,7 +54,7 @@
         <div class="validation-pop-up-wrapper">
             <div class="validation-pop-up"
                  data-ng-show="$ctrl.isValidationPopUpShown"
-                 data-ng-class="$ctrl.isOverflowed() ? 'validation-pop-up-top' : 'validation-pop-up-bottom'">
+                 data-ng-class="$ctrl.showPopUpOnTop ? 'validation-pop-up-top' : 'validation-pop-up-bottom'">
                 <div class="validation-rule"
                      data-ng-repeat="rule in $ctrl.validationRules">
                     <span class="validation-rule-icon"
@@ -96,6 +97,7 @@
         <div class="validation-icon"
              data-ng-if="$ctrl.validationRules.length > 0 && !$ctrl.readOnly && ($ctrl.inputFocused || $ctrl.isFieldInvalid())"
              data-ng-mousedown="$ctrl.preventInputBlur = true"
+             data-ng-click="$ctrl.toggleValidationPopUp()"
              data-ng-class="[$ctrl.inputFocused ? '' : $ctrl.bordersModeClass, {
                  'igz-icon-verify-info': $ctrl.inputIsTouched && $ctrl.data === '',
                  'igz-icon-verify-error': $ctrl.hasInvalidRule() && $ctrl.data !== '',
@@ -136,8 +138,9 @@
         <span data-ng-if="$ctrl.inputIcon" class="input-icon {{$ctrl.inputIcon}}"></span>
 
         <div class="validation-pop-up-wrapper">
-            <div class="validation-pop-up validation-pop-up-top"
-                 data-ng-show="$ctrl.isValidationPopUpShown">
+            <div class="validation-pop-up"
+                 data-ng-show="$ctrl.isValidationPopUpShown"
+                 data-ng-class="$ctrl.showPopUpOnTop ? 'validation-pop-up-top' : 'validation-pop-up-bottom'">
                 <div class="validation-rule"
                      data-ng-repeat="rule in $ctrl.validationRules">
                     <span class="validation-rule-icon"


### PR DESCRIPTION
When validation pop-up is open clicking below the field is blocked by an invisible wrapper of the validation pop-up.
![image](https://user-images.githubusercontent.com/13918850/92257761-6d2c6d80-eede-11ea-84f0-e9e0770aac0d.png)
