### PR TITLE
Fix [Nuclio] Configuration: Onbuild image description obstructed

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -154,7 +154,7 @@
     "NOT_START_WITH_FORBIDDEN_WORDS": "Must not start with 'kubernetes.io' or 'k8s.io'",
     "NOT_YET_DEPLOYED": "Not yet deployed",
     "ONBUILD_IMAGE": "Onbuild image",
-    "ONBUILD_IMAGE_DESCRIPTION": "The name of an \"onbuild\" container image from which to build the function's processor image; the name can include {\\{ .Label }} and {\\{ .Arch }} for formatting",
+    "ONBUILD_IMAGE_DESCRIPTION": "The name of an \"onbuild\" container image from which to build the function's processor image; the name can include {{ .Label }} and {{ .Arch }} for formatting",
     "OVERRIDE": "Override",
     "PATH_DESCRIPTION": "A relative directory path within the data container",
     "PERSISTENT_VOLUME_CLAIM_NAME": "Persistent Volume Claim Name",

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
@@ -37,6 +37,7 @@
         };
         ctrl.disabled = true;
         ctrl.platformKindIsKube = false;
+        ctrl.onBuildImageDescription = '';
 
         ctrl.defaultFunctionConfig = lodash.get(ConfigService, 'nuclio.defaultFunctionConfig.attributes', {});
         ctrl.imageNameValidationPattern = ValidationService.dockerReference;
@@ -63,6 +64,13 @@
          * Initialization method
          */
         function onInit() {
+            ctrl.onBuildImageDescription = $i18next.t('functions:ONBUILD_IMAGE_DESCRIPTION', {
+                interpolation: {
+                    prefix: '__',
+                    suffix: '__'
+                },
+                lng: lng
+            });
             ctrl.platformKindIsKube = lodash.get(ConfigService, 'nuclio.platformKind') === 'kube';
         }
 

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
@@ -62,7 +62,8 @@
                 <div class="field-label label-with-tooltip align-items-center">
                     <span>{{ 'functions:ONBUILD_IMAGE' | i18next }}</span>
                     <igz-more-info
-                            data-description="{{ 'functions:ONBUILD_IMAGE_DESCRIPTION' | i18next }}"
+                            data-description="{{$ctrl.onBuildImageDescription}}"
+                            data-default-tooltip-placement="left"
                             data-trigger="click">
                     </igz-more-info>
                 </div>


### PR DESCRIPTION
Also, it has redundant forward slash characters: `{\{` instead of `{{`.

Before:
![image](https://user-images.githubusercontent.com/13918850/92261175-b0d4a680-eee1-11ea-9381-85d616903cbf.png)

After:
![image](https://user-images.githubusercontent.com/13918850/92261186-b3370080-eee1-11ea-84c0-3d6a4cbf36e5.png)
