### PR TITLE
Impl [Nuclio] Basic Settings: omit empty security context props

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
@@ -97,16 +97,19 @@
                 if (ctrl.basicSettingsForm.$valid) {
                     if (lodash.includes(field, 'timeout')) {
                         lodash.set(ctrl.version, 'spec.timeoutSeconds', ctrl.timeout.min * 60 + ctrl.timeout.sec);
+                    } else if (lodash.startsWith(field, 'spec.securityContext.') && newData === '') {
+                        lodash.unset(ctrl.version, field);
                     } else {
                         lodash.set(ctrl.version, field, newData);
                     }
 
-                    $rootScope.$broadcast('change-state-deploy-button', {component: 'settings', isDisabled: false});
-
                     ctrl.onChangeCallback();
-                } else {
-                    $rootScope.$broadcast('change-state-deploy-button', {component: 'settings', isDisabled: true});
                 }
+
+                $rootScope.$broadcast('change-state-deploy-button', {
+                    component: 'settings',
+                    isDisabled: !ctrl.basicSettingsForm.$valid
+                });
             });
         }
 


### PR DESCRIPTION
When any one of "FS Group", "Run as user", & "Run as group" is empty — omit it from deploy request instead of having an empty string.

Before:

```json
{
  "spec": {
    "securityContext": {
      "fsGroup": "",
      "runAsGroup": "",
      "runAsUser": ""
    }
  }
}
```

After:

```json
{
  "spec": {
    "securityContext": {}
  }
}
```