### PR TITLE
[Nuclio] Triggers: add default HTTP trigger & Service Type

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -299,6 +299,7 @@
     "MOVE": "Move",
     "MUST_CONTAIN_EXACTLY_ONE": "Must contain exactly one",
     "MUST_HAVE_DOT_AFTER_AT": "Must have at least one . after @",
+    "MUST_NOT_BE": "Must not be",
     "N_A": "N/A",
     "NAME": "Name",
     "NAME_IS_REQUIRED": "Name is required",

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -118,6 +118,8 @@
     "HOST": "Host",
     "HOST_PATH": "Host path",
     "HUGE": "Huge",
+    "HTTP_TRIGGER_MSG": "You currently didn’t add an HTTP trigger. If you deploy the function without specifying one, Nuclio will add it automatically on deploy with a default configuration. If you want to configure the HTTP trigger differently — &nbsp;<a class=\"link\" data-ng-click=\"$ctrl.addDefaultHttpTrigger()\">add it here</a>&nbsp; and edit it.",
+    "HTTP_TRIGGER_NAME_DESCRIPTION": "If the name of the HTTP trigger is <b>default-http</b> it might get overridden by a remote function specification configured in <b>Code Entry Type.</b>",
     "IMAGE_NAME": "Image name",
     "IMAGE_NAME_DESCRIPTION": "The name of the built container image (default for this function: <b>{{defaultImageName}}</b>)",
     "IMPORT": "Import",

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -118,7 +118,7 @@
     "HOST": "Host",
     "HOST_PATH": "Host path",
     "HUGE": "Huge",
-    "HTTP_TRIGGER_MSG": "You currently didn’t add an HTTP trigger. If you deploy the function without specifying one, Nuclio will add it automatically on deploy with a default configuration. If you want to configure the HTTP trigger differently — &nbsp;<a class=\"link\" data-ng-click=\"$ctrl.addDefaultHttpTrigger()\">add it here</a>&nbsp; and edit it.",
+    "HTTP_TRIGGER_MSG": "You currently didn’t add an HTTP trigger. If you deploy the function without specifying one, Nuclio will add it automatically on deploy with a default configuration. If you want to configure the HTTP trigger differently —&nbsp;<a class=\"link\" data-ng-click=\"$ctrl.addDefaultHttpTrigger()\">add it here</a>&nbsp;and edit it.",
     "HTTP_TRIGGER_NAME_DESCRIPTION": "If the name of the HTTP trigger is <b>default-http</b> it might get overridden by a remote function specification configured in <b>Code Entry Type.</b>",
     "IMAGE_NAME": "Image name",
     "IMAGE_NAME_DESCRIPTION": "The name of the built container image (default for this function: <b>{{defaultImageName}}</b>)",

--- a/src/igz_controls/components/more-info/more-info.less
+++ b/src/igz_controls/components/more-info/more-info.less
@@ -63,6 +63,7 @@
         font-size: 12px;
         font-weight: 400;
         white-space: pre-line;
+        line-height: normal;
         z-index: 9999;
 
         &::before {

--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.js
@@ -288,7 +288,7 @@
             if (angular.isDefined(changes.validationRules)) {
                 ctrl.validationRules = angular.copy(lodash.defaultTo(changes.validationRules.currentValue, []));
 
-                if (ctrl.data !== '') {
+                if (ctrl.data !== '' && !changes.validationRules.isFirstChange()) {
                     ngModel.$validate();
                 }
             }

--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.js
@@ -287,6 +287,10 @@
 
             if (angular.isDefined(changes.validationRules)) {
                 ctrl.validationRules = angular.copy(lodash.defaultTo(changes.validationRules.currentValue, []));
+
+                if (ctrl.data !== '') {
+                    ngModel.$validate();
+                }
             }
         }
 

--- a/src/igz_controls/components/validating-input-field/validating-input-field.component.spec.js
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.component.spec.js
@@ -61,9 +61,9 @@ describe('igzValidatingInputField component:', function () {
 
         ctrl = $componentController('igzValidatingInputField', { $element: element }, bindings);
         ctrl.$onInit();
-        ctrl.$onChanges(changes);
         ctrl.$postLink();
         $rootScope.$apply();
+        ctrl.$onChanges(changes);
     });
 
     afterEach(function () {

--- a/src/igz_controls/less/helpers.less
+++ b/src/igz_controls/less/helpers.less
@@ -233,3 +233,18 @@
         margin-left: 8px;
     }
 }
+
+.content-message-pane {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    text-align: center;
+    width: 100%;
+    min-height: 50px;
+    margin: 10px 0;
+    padding: 10px 20px;
+    border: 1px solid #e1e0e5;
+    color: #474056;
+    font-size: 14px;
+}

--- a/src/igz_controls/less/helpers.less
+++ b/src/igz_controls/less/helpers.less
@@ -235,15 +235,11 @@
 }
 
 .content-message-pane {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
     text-align: center;
     width: 100%;
     min-height: 50px;
     margin: 10px 0;
-    padding: 10px 20px;
+    padding: 14px 20px;
     border: 1px solid #e1e0e5;
     color: #474056;
     font-size: 14px;

--- a/src/nuclio/common/components/collapsing-row/collapsing-row.less
+++ b/src/nuclio/common/components/collapsing-row/collapsing-row.less
@@ -58,7 +58,12 @@
 
         .item-name {
             font-weight: bold;
+            display: flex;
             width: 192px;
+
+            .text-ellipsis {
+                width: auto;
+            }
         }
 
         .item-class {

--- a/src/nuclio/common/components/collapsing-row/collapsing-row.tpl.html
+++ b/src/nuclio/common/components/collapsing-row/collapsing-row.tpl.html
@@ -11,8 +11,17 @@
         <div data-ng-show="!$ctrl.item.ui.editModeActive" class="igz-row common-table-cells-container item-row">
 
             <!-- Name -->
-            <div class="text-ellipsis item-name" data-ng-if="!$ctrl.isNil($ctrl.item.name)">
-                {{$ctrl.item.name}}
+            <div class="item-name" data-ng-if="!$ctrl.isNil($ctrl.item.name)">
+                <div class="text-ellipsis" >
+                    {{$ctrl.item.name}}
+                </div>
+                <igz-more-info data-ng-if="$ctrl.item.ui.moreInfoMsg.name"
+                               data-trigger="click"
+                               data-is-html-enabled="true"
+                               data-is-open="$ctrl.item.ui.moreInfoMsg.name.isOpen"
+                               data-icon-type="{{$ctrl.item.ui.moreInfoMsg.name.type}}"
+                               data-description="{{$ctrl.item.ui.moreInfoMsg.name.description}}">
+                </igz-more-info>
             </div>
             <div class="text-ellipsis item-name" data-ng-if="!$ctrl.isNil($ctrl.item.volumeMount.name)">
                 {{ $ctrl.item.volumeMount.name }}

--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -90,6 +90,8 @@
          */
         // eslint-disable-next-line
         function onInit() {
+            ctrl.validationRules = angular.copy(ctrl.validationRules);
+
             lodash.defaults(ctrl, {
                 classPlaceholder: $i18next.t('functions:PLACEHOLDER.SELECT_CLASS', { lng: lng })
             });
@@ -145,6 +147,8 @@
                     })
                     .value();
             }
+
+            updateNameValidationRules()
 
             if (ctrl.isTriggerType() && ctrl.isKafkaTrigger()) {
                 lodash.defaultsDeep(ctrl.item.attributes, {
@@ -246,6 +250,24 @@
             setAdvancedVisibility();
 
             $scope.$on('deploy-function-version', onFunctionDeploy);
+        }
+
+        function updateNameValidationRules() {
+            if (ctrl.isTriggerType() && !lodash.isEmpty(ctrl.selectedClass) && !ctrl.isHttpTrigger()) {
+                if (!lodash.find(ctrl.validationRules.itemName, ['name', 'mustNotBe'])) {
+                    ctrl.validationRules.itemName.push({
+                        name: 'mustNotBe',
+                        label: $i18next.t('common:MUST_NOT_BE', {lng: lng}) + ': default-http',
+                        pattern: function (value) {
+                            return value !== 'default-http'
+                        }
+                    })
+                }
+            } else {
+                lodash.remove(ctrl.validationRules.itemName, function (rule) {
+                    return rule.name === 'mustNotBe'
+                })
+            }
         }
 
         /**
@@ -769,6 +791,7 @@
 
             setAdvancedVisibility();
             updateChangesState();
+            updateNameValidationRules();
         }
 
         /**

--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -148,7 +148,7 @@
                     .value();
             }
 
-            updateNameValidationRules()
+            updateNameValidationRules();
 
             if (ctrl.isTriggerType() && ctrl.isKafkaTrigger()) {
                 lodash.defaultsDeep(ctrl.item.attributes, {
@@ -259,14 +259,12 @@
                         name: 'mustNotBe',
                         label: $i18next.t('common:MUST_NOT_BE', {lng: lng}) + ': default-http',
                         pattern: function (value) {
-                            return value !== 'default-http'
+                            return value !== 'default-http';
                         }
-                    })
+                    });
                 }
             } else {
-                lodash.remove(ctrl.validationRules.itemName, function (rule) {
-                    return rule.name === 'mustNotBe'
-                })
+                lodash.remove(ctrl.validationRules.itemName, ['name', 'mustNotBe']);
             }
         }
 
@@ -556,7 +554,7 @@
                 return lodash.defaultTo(field.visible, true) &&
                     lodash.includes(['input', 'dropdown', 'number-input', 'arrayInt'], field.type) &&
                     (showAdvanced ? field.isAdvanced : !field.isAdvanced);
-            }
+            };
         }
 
         /**
@@ -786,7 +784,7 @@
             }
 
             if (lodash.isFunction(ctrl.onSelectClassCallback)) {
-                ctrl.onSelectClassCallback()
+                ctrl.onSelectClassCallback();
             }
 
             setAdvancedVisibility();
@@ -850,7 +848,7 @@
                                 .value();
 
                             if (isAdvancedInvalid) {
-                                ctrl.isAdvancedCollapsed = false
+                                ctrl.isAdvancedCollapsed = false;
                             }
                         }
 
@@ -899,8 +897,8 @@
 
             return lodash.every(elementsForValidation, function (element) {
                 return element === '.mCustomScrollBox' && event.target.closest('.row-collapse') ||
-                    !event.target.closest(element)
-            })
+                    !event.target.closest(element);
+            });
         }
 
         /**
@@ -937,7 +935,7 @@
          * @param {{event: MouseEvent|KeyboardEvent}} data - broadcast data with DOM event
          */
         function onFunctionDeploy(event, data) {
-            ctrl.onSubmitForm(data.event)
+            ctrl.onSubmitForm(data.event);
         }
 
         /**

--- a/src/nuclio/common/services/version-helper.service.js
+++ b/src/nuclio/common/services/version-helper.service.js
@@ -30,13 +30,13 @@
                     return {
                         text: ingresses[0].host,
                         valid: true
-                    }
+                    };
                 }
 
                 var serviceType = lodash.get(httpTrigger, 'attributes.serviceType', null);
                 var state = lodash.get(version, 'status.state', null);
                 var disable = lodash.get(version, 'spec.disable', false);
-                var httpPort = lodash.get(version, 'status.httpPort', null)
+                var httpPort = lodash.get(version, 'status.httpPort', null);
                 var externalIPAddress = ConfigService.nuclio.externalIPAddress;
 
                 if (serviceType === 'NodePort' &&
@@ -48,7 +48,7 @@
                     return {
                         text: 'http://' + externalIPAddress + ':' + httpPort,
                         valid: true
-                    }
+                    };
 
                 }
             }
@@ -56,7 +56,7 @@
             return {
                 text: 'URL not exposed',
                 valid: false
-            }
+            };
         }
 
         /**

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -21,7 +21,8 @@
 
     function NclFunctionCollapsingRowController($interval, $state, $i18next, i18next, lodash, ngDialog,
                                                 ActionCheckboxAllService, ConfigService, DialogsService,
-                                                ExportService, FunctionsService, NuclioHeaderService, TableSizeService) {
+                                                ExportService, FunctionsService, NuclioHeaderService, TableSizeService,
+                                                VersionHelperService) {
         var ctrl = this;
 
         var apiGateways = [];
@@ -129,19 +130,11 @@
          * @param {Object} changes
          */
         function onChanges(changes) {
-            var httpPort = lodash.get(ctrl.function, 'status.httpPort', 0);
             if (lodash.has(changes, 'function')) {
-                var externalAddress = ConfigService.nuclio.externalIPAddress;
-
                 convertStatusState();
                 setStatusIcon();
 
-                ctrl.invocationUrl = {
-                    text: lodash.isEmpty(externalAddress) ? $i18next.t('common:N_A', {lng: lng})                 :
-                          lodash.toFinite(httpPort) === 0 ? $i18next.t('functions:NOT_YET_DEPLOYED', {lng: lng}) :
-                                                            'http://' + externalAddress + ':' + httpPort,
-                    valid: !lodash.isEmpty(externalAddress) && lodash.toFinite(httpPort) !== 0
-                };
+                ctrl.invocationUrl = VersionHelperService.getInvocationUrl(ctrl.function);
             }
         }
 

--- a/src/nuclio/functions/functions.less
+++ b/src/nuclio/functions/functions.less
@@ -25,12 +25,4 @@ ncl-functions {
       }
     }
   }
-
-  .search-input-not-found {
-    height: 48px;
-    background-color: @light-grey;
-    border: solid 1px @pale-grey;
-    font-size: 14px;
-    color: @dusk-three;
-  }
 }

--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -467,6 +467,25 @@
                                 allowEmpty: true
                             },
                             {
+                                name: 'serviceType',
+                                values: [
+                                    {
+                                        id: 'ClusterIP',
+                                        name: 'Cluster IP',
+                                        visible: true
+                                    },
+                                    {
+                                        id: 'NodePort',
+                                        name: 'Node Port',
+                                        visible: true
+                                    }
+                                ],
+                                path: 'attributes.serviceType',
+                                type: 'dropdown',
+                                allowEmpty: true,
+                                isAdvanced: true
+                            },
+                            {
                                 name: 'annotations',
                                 type: 'key-value'
                             }

--- a/src/nuclio/functions/functions.tpl.html
+++ b/src/nuclio/functions/functions.tpl.html
@@ -129,7 +129,7 @@
                 <div class="common-table-cell actions-menu">&nbsp;</div>
             </div>
 
-            <div class="search-input-not-found"
+            <div class="content-message-pane"
                  data-ng-if="$ctrl.isFunctionsListEmpty()">
                 {{ 'functions:FUNCTIONS_NOT_FOUND' | i18next }}
             </div>

--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
@@ -152,7 +152,6 @@
         ctrl.deleteEvent = deleteEvent;
         ctrl.deleteFile = deleteFile;
         ctrl.fixLeftBar = fixLeftBar;
-        ctrl.getInvocationUrl = getInvocationUrl;
         ctrl.getMethodColor = getMethodColor;
         ctrl.handleAction = handleAction;
         ctrl.inputValueCallback = inputValueCallback;
@@ -352,23 +351,6 @@
          */
         function fixLeftBar() {
             ctrl.fixedLeftBar = true;
-        }
-
-        /**
-         * Gets invocation url
-         * @returns {string}
-         */
-        function getInvocationUrl() {
-            var status = lodash.get(ctrl.version, 'status', {});
-
-            if (lodash.toFinite(status.httpPort) === 0 || !lodash.includes(['ready', 'scaledToZero'], status.state)) {
-                status.httpPort = null;
-            }
-
-            setInvocationUrl(ConfigService.nuclio.externalIPAddress, status.httpPort);
-
-            return lodash.isNull(status.httpPort) ? $i18next.t('functions:NOT_YET_DEPLOYED', {lng: lng}) :
-                                                    lodash.trimEnd(ctrl.version.ui.invocationUrl, '/') + '/';
         }
 
         /**
@@ -916,16 +898,6 @@
 
             localStorage.setItem('test-events', angular.toJson(updatedHistory));
             updateHistory();
-        }
-
-        /**
-         * Sets the invocation URL of the function
-         * @param {string} ip - external IP address
-         * @param {number} port - HTTP port
-         */
-        function setInvocationUrl(ip, port) {
-            ctrl.version.ui.invocationUrl =
-                lodash.isEmpty(ip) || lodash.toFinite(port) === 0 ? '' : 'http://' + ip + ':' + port;
         }
 
         /**

--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.less
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.less
@@ -283,9 +283,12 @@
             .path {
                 display: flex;
                 align-items: center;
-                color: @cool-grey;
                 font-weight: bold;
                 margin-left: 22px;
+
+                .invocation-url {
+                    color: @cool-grey;
+                }
             }
 
             .default-dropdown {

--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.tpl.html
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.tpl.html
@@ -106,7 +106,12 @@
                                                       data-enable-overlap="true">
                                 </igz-default-dropdown>
                                 <div class="path">
-                                    {{$ctrl.getInvocationUrl()}}
+                                    <span class="invocation-url" data-ng-if="$ctrl.version.ui.invocationUrl.valid">
+                                        {{$ctrl.version.ui.invocationUrl.text}}/
+                                    </span>
+                                    <span data-ng-if="!$ctrl.version.ui.invocationUrl.valid">
+                                        {{ 'common:PATH' | i18next }}:
+                                    </span>
                                     <igz-validating-input-field data-field-type="input"
                                                                 data-input-value="$ctrl.selectedEvent.spec.attributes.path"
                                                                 data-update-data-field="spec.attributes.path"

--- a/src/nuclio/functions/version/version-monitoring/version-monitoring.tpl.html
+++ b/src/nuclio/functions/version/version-monitoring/version-monitoring.tpl.html
@@ -8,25 +8,20 @@
                     <span class="monitoring-block-title">
                         {{ 'functions:INVOCATION_URL' | i18next }}:
                     </span>
-                    <div class="monitoring-invocation-url-wrapper"
-                         data-ng-if="($ctrl.version.status.state === 'ready' || $ctrl.version.status.state === 'scaledToZero') && $ctrl.version.ui.invocationUrl !== ''">
+                    <div class="monitoring-invocation-url-wrapper" data-ng-if="$ctrl.version.ui.invocationUrl.valid">
                         <a class="monitoring-invocation-url"
-                           href="{{$ctrl.version.ui.invocationUrl}}">
-                            {{$ctrl.version.ui.invocationUrl}}
+                           href="{{$ctrl.version.ui.invocationUrl.text}}">
+                            {{$ctrl.version.ui.invocationUrl.text}}
                         </a>
                         <div class="igz-action-panel">
                             <div class="actions-list">
-                                <igz-copy-to-clipboard data-value="$ctrl.version.ui.invocationUrl"></igz-copy-to-clipboard>
+                                <igz-copy-to-clipboard data-value="$ctrl.version.ui.invocationUrl.text"></igz-copy-to-clipboard>
                             </div>
                         </div>
                     </div>
-                    <span data-ng-if="($ctrl.version.status.state === 'ready' || $ctrl.version.status.state === 'scaledToZero') && $ctrl.version.ui.invocationUrl === ''"
+                    <span data-ng-if="!$ctrl.version.ui.invocationUrl.valid"
                           class="monitoring-invocation-field-invalid">
-                        {{ 'common:N_A' | i18next }}
-                    </span>
-                    <span data-ng-if="$ctrl.version.status.state !== 'ready' && $ctrl.version.status.state !== 'scaledToZero'"
-                          class="monitoring-invocation-field-invalid">
-                        {{ 'functions:NOT_YET_DEPLOYED' | i18next }}
+                            {{$ctrl.version.ui.invocationUrl.text}}
                     </span>
                 </div>
                 <div class="monitoring-block"

--- a/src/nuclio/functions/version/version-triggers/version-triggers.component.js
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.component.js
@@ -11,8 +11,9 @@
             controller: NclVersionTriggersController
         });
 
-    function NclVersionTriggersController($i18next, $rootScope, $scope, $timeout, i18next, lodash, ConfigService,
-                                          DialogsService, FunctionsService, ValidationService, VersionHelperService) {
+    function NclVersionTriggersController($i18next, $rootScope, $scope, $timeout, $window, i18next, lodash,
+                                          ConfigService, DialogsService, FunctionsService, ValidationService,
+                                          VersionHelperService) {
         var ctrl = this;
         var lng = i18next.language;
         var uniqueClasses = ['http'];
@@ -135,6 +136,10 @@
 
                 updateTriggerInfoMsg(triggerItem, true);
                 checkClassUniqueness();
+
+                $timeout(function () {
+                    $window.dispatchEvent(new Event('resize'));
+                });
             }
         }
 

--- a/src/nuclio/functions/version/version-triggers/version-triggers.component.js
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.component.js
@@ -122,18 +122,18 @@
          * Adds default HTTP trigger to the trigger list
          */
         function addDefaultHttpTrigger() {
-            var defaultTriggers = lodash.get(ConfigService, 'nuclio.defaultFunctionConfig.attributes.spec.triggers')
-            var defaultHttpTrigger = lodash.find(defaultTriggers, ['kind', 'http'])
+            var defaultTriggers = lodash.get(ConfigService, 'nuclio.defaultFunctionConfig.attributes.spec.triggers');
+            var defaultHttpTrigger = angular.copy(lodash.find(defaultTriggers, ['kind', 'http']));
 
             if (!lodash.isEmpty(defaultHttpTrigger)) {
-                var triggers = lodash.get(ctrl.version, 'spec.triggers', {})
-                var triggerItem = createTriggerItem(defaultHttpTrigger)
-                triggers[defaultHttpTrigger.name] = defaultHttpTrigger
+                var triggers = lodash.get(ctrl.version, 'spec.triggers', {});
+                var triggerItem = createTriggerItem(defaultHttpTrigger);
+                triggers[defaultHttpTrigger.name] = defaultHttpTrigger;
 
                 lodash.set(ctrl.version, 'spec.triggers', triggers);
-                ctrl.triggers.push(triggerItem)
+                ctrl.triggers.push(triggerItem);
 
-                updateTriggerInfoMsg(triggerItem, true)
+                updateTriggerInfoMsg(triggerItem, true);
                 checkClassUniqueness();
             }
         }
@@ -152,7 +152,7 @@
                         classData.tooltipOriginal,
                     disabled: classIsUsed
                 });
-            })
+            });
         }
 
         /**
@@ -222,9 +222,8 @@
          * @returns {boolean} `true` in case "HTTP trigger message" is shown, or `false` otherwise.
          */
         function isHttpTriggerMsgShown() {
-            var httpTrigger = lodash.find(ctrl.version.spec.triggers, ['kind', 'http'])
-
-            return lodash.isNil(httpTrigger)
+            var httpTrigger = lodash.find(ctrl.version.spec.triggers, ['kind', 'http']);
+            return lodash.isNil(httpTrigger);
         }
 
         //
@@ -233,27 +232,28 @@
 
         /**
          * Creates the new trigger item
-         * @param {Object} [trigger] - trigger data from `ctrl.version`
+         * @param {Object} [trigger] - trigger object
          * @returns {Object} - trigger item
          */
         function createTriggerItem(trigger) {
-            var triggerItem = lodash.assign(trigger ? trigger : {}, {
-                id: trigger ? trigger.name : '',
-                name: trigger ? trigger.name : '',
-                kind: trigger ? trigger.kind : '',
+            var noTriggerProvided = lodash.isNil(trigger);
+            var triggerItem = lodash.assign({}, noTriggerProvided ? {} : trigger, {
+                id: noTriggerProvided ? '' : trigger.name,
+                name: noTriggerProvided ? '' : trigger.name,
+                kind: noTriggerProvided ? '' : trigger.kind,
                 ui: {
-                    changed: lodash.isNil(trigger),
-                    editModeActive: lodash.isNil(trigger),
-                    isFormValid: !lodash.isNil(trigger),
+                    changed: noTriggerProvided,
+                    editModeActive: noTriggerProvided,
+                    isFormValid: !noTriggerProvided,
                     name: 'trigger',
-                    selectedClass: trigger ? lodash.find(ctrl.classList, ['id', trigger.kind]) : ''
+                    selectedClass: noTriggerProvided ? '' : lodash.find(ctrl.classList, ['id', trigger.kind])
                 }
-            })
+            });
 
-            if (!trigger) {
+            if (noTriggerProvided) {
                 lodash.merge(triggerItem, {
                     attributes: {},
-                })
+                });
             }
 
             return triggerItem;
@@ -271,7 +271,7 @@
 
             $timeout(function () {
                 $rootScope.$broadcast('igzWatchWindowResize::resize');
-            })
+            });
         }
 
         /**
@@ -386,9 +386,9 @@
                         type: trigger.name === 'default-http' ? 'warn' : 'info',
                         description: $i18next.t('functions:HTTP_TRIGGER_NAME_DESCRIPTION', {lng: lng})
                     }
-                })
+                });
             } else {
-                lodash.unset(trigger, 'ui.moreInfoMsg')
+                lodash.unset(trigger, 'ui.moreInfoMsg');
             }
         }
 

--- a/src/nuclio/functions/version/version-triggers/version-triggers.tpl.html
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.tpl.html
@@ -1,5 +1,8 @@
 <div class="ncl-version-trigger ncl-version">
     <div class="common-table">
+        <div class="content-message-pane"
+             data-ng-if="$ctrl.isHttpTriggerMsgShown()" ng-i18next="[html]functions:HTTP_TRIGGER_MSG">
+        </div>
         <div class="common-table-header header-row">
             <div class="common-table-cell header-name">
                 {{ 'common:NAME' | i18next }}
@@ -14,9 +17,6 @@
         <div class="content-message-pane"
              data-ng-if="$ctrl.triggers.length === 0">
             {{ 'functions:TRIGGERS_NOT_FOUND' | i18next }}
-        </div>
-        <div class="content-message-pane"
-             data-ng-if="$ctrl.isHttpTriggerMsgShown()" ng-i18next="[html]functions:HTTP_TRIGGER_MSG">
         </div>
 
         <div class="common-table-body" data-igz-extend-background>

--- a/src/nuclio/functions/version/version-triggers/version-triggers.tpl.html
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.tpl.html
@@ -11,11 +11,12 @@
                 {{ 'common:INFO' | i18next }}
             </div>
         </div>
-        <div class="search-input-not-found"
+        <div class="content-message-pane"
              data-ng-if="$ctrl.triggers.length === 0">
-            <div class="search-message">
-                {{ 'functions:TRIGGERS_NOT_FOUND' | i18next }}
-            </div>
+            {{ 'functions:TRIGGERS_NOT_FOUND' | i18next }}
+        </div>
+        <div class="content-message-pane"
+             data-ng-if="$ctrl.isHttpTriggerMsgShown()" ng-i18next="[html]functions:HTTP_TRIGGER_MSG">
         </div>
 
         <div class="common-table-body" data-igz-extend-background>

--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -526,11 +526,7 @@
          * Sets the invocation URL of the function
          */
         function setInvocationUrl() {
-            var ip = ConfigService.nuclio.externalIPAddress;
-            var port = lodash.get(ctrl.version, 'status.httpPort');
-
-            ctrl.version.ui.invocationUrl =
-                lodash.isEmpty(ip) || lodash.toFinite(port) === 0 ? '' : 'http://' + ip + ':' + port;
+            ctrl.version.ui.invocationUrl = VersionHelperService.getInvocationUrl(ctrl.version);
         }
 
         /**

--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -384,7 +384,7 @@
                 })
                 .finally(function () {
                     ctrl.isSplashShowed.value = false;
-                })
+                });
         }
 
         /**


### PR DESCRIPTION
https://trello.com/c/waVyV9yt/550-nuclio-triggers-add-default-http-trigger-service-type

- Added message about auto-add of default HTTP trigger on backend
  ![image](https://user-images.githubusercontent.com/13918850/96166434-a7018280-0f26-11eb-85b7-1a474e8b4bba.png)
- Added warning message about naming HTTP trigger **default-http**
  ![image](https://user-images.githubusercontent.com/13918850/96166470-b1bc1780-0f26-11eb-9065-0bf9cc683512.png)
- Added **Service type** field in **Advanced** section of HTTP trigger
  ![image](https://user-images.githubusercontent.com/13918850/96166602-d87a4e00-0f26-11eb-8104-bc619db78c37.png)
- When **Cluster IP** is selected in **Service type**:
  - “URL not exposed” is displayed for **Invocation URL** columns in function list
    ![image](https://user-images.githubusercontent.com/13918850/96166651-ec25b480-0f26-11eb-8106-6e47e0d3ee55.png)
  - “URL not exposed” is displayed for **Invocation URL** field in **Status** tab
    ![image](https://user-images.githubusercontent.com/13918850/96166756-14adae80-0f27-11eb-9fa3-e27b9185da8f.png)
  - “Path” label is displayed for **Path** field in **Test** pane of **Code** tab, instead of the IP address and port number
    ![image](https://user-images.githubusercontent.com/13918850/96166724-0495cf00-0f27-11eb-9ab9-add661e0c047.png)

