### PR TITLE
Fix [Nuclio] Wrong conditions for Invocation URL and Test button

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -325,6 +325,7 @@
     "TRIGGERS_NOT_FOUND": "There are currently no triggers, you can create a trigger by clicking the ‘Create a new trigger’ button",
     "UNIQUENESS": "Uniqueness",
     "UNSPECIFIED_FIELD_NAME": "Unspecified field name",
+    "URL_NOT_EXPOSED": "URL not exposed",
     "V3IO": "V3IO",
     "VIEW_YAML": "View YAML",
     "VOLUMES": "Volumes",

--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -5,14 +5,17 @@
         .factory('FunctionsService', FunctionsService);
 
     function FunctionsService($i18next, i18next, lodash, ngDialog, ConfigService) {
-        return {
+        var self = {
             checkedItem: '',
             getClassesList: getClassesList,
             getHandler: getHandler,
             initFunctionActions: initFunctionActions,
             initVersionActions: initVersionActions,
+            isKubePlatform: isKubePlatform,
             openOverrideFunctionDialog: openOverrideFunctionDialog
         };
+
+        return self;
 
         //
         // Public methods
@@ -27,7 +30,6 @@
         function getClassesList(type, additionalData) {
             var lng = i18next.language;
             var defaultFunctionConfig = lodash.get(ConfigService, 'nuclio.defaultFunctionConfig.attributes', {});
-            var platformKindIsKube = lodash.get(ConfigService, 'nuclio.platformKind') === 'kube';
             var classesList = {
                 trigger: [
                     {
@@ -297,7 +299,7 @@
                                 min: 1,
                                 max: 100000,
                                 defaultValue: 1,
-                                visible: !platformKindIsKube
+                                visible: !self.isKubePlatform()
                             },
                             {
                                 name: 'workerAvailabilityTimeoutMilliseconds',
@@ -312,7 +314,7 @@
                                                             'spec.triggers.cron.workerAvailabilityTimeoutMilliseconds',
                                                             '')
                                     }),
-                                visible: !platformKindIsKube
+                                visible: !self.isKubePlatform()
                             },
                             {
                                 name: 'interval',
@@ -349,9 +351,9 @@
                                 name: 'workerAllocatorName',
                                 type: 'input',
                                 fieldType: 'input',
-                                isAdvanced: !platformKindIsKube,
+                                isAdvanced: !self.isKubePlatform(),
                                 allowEmpty: true,
-                                visible: !platformKindIsKube
+                                visible: !self.isKubePlatform()
                             }
                         ]
                     },
@@ -483,7 +485,8 @@
                                 path: 'attributes.serviceType',
                                 type: 'dropdown',
                                 allowEmpty: true,
-                                isAdvanced: true
+                                isAdvanced: true,
+                                visible: self.isKubePlatform()
                             },
                             {
                                 name: 'annotations',
@@ -894,6 +897,14 @@
                     }
                 }
             ];
+        }
+
+        /**
+         * Tests whether Nuclio runs on Kubernetes platform.
+         * @returns {boolean} `true` in case Nuclio runs on Kubernetes platform, or `false` otherwise.
+         */
+        function isKubePlatform() {
+            return lodash.get(ConfigService, 'nuclio.platformKind') === 'kube';
         }
 
         /**

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
@@ -12,7 +12,7 @@
         });
 
     function NclVersionConfigurationBuildController($rootScope, $scope, $timeout, $i18next, i18next, lodash, ngDialog,
-                                                    Upload, ConfigService, ValidationService) {
+                                                    Upload, ConfigService, FunctionsService, ValidationService) {
         var ctrl = this;
         var lng = i18next.language;
         var uploadType = '';
@@ -71,7 +71,7 @@
                 },
                 lng: lng
             });
-            ctrl.platformKindIsKube = lodash.get(ConfigService, 'nuclio.platformKind') === 'kube';
+            ctrl.platformKindIsKube = FunctionsService.isKubePlatform();
         }
 
         /**

--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -22,7 +22,7 @@
 
     function NclVersionController($i18next, $interval, $rootScope, $scope, $state, $stateParams, $transitions, $timeout,
                                   i18next, lodash, ngDialog, ConfigService, DialogsService, ExportService,
-                                  NuclioHeaderService, VersionHelperService) {
+                                  FunctionsService, NuclioHeaderService, VersionHelperService) {
         var ctrl = this;
         var deregisterFunction = null;
         var interval = null;
@@ -191,7 +191,7 @@
                 }
             });
 
-            if (lodash.get(ConfigService, 'nuclio.platformKind') === 'kube') {
+            if (FunctionsService.isKubePlatform()) {
                 lodash.defaults(ctrl.version.spec, {
                     waitReadinessTimeoutBeforeFailure: false
                 });


### PR DESCRIPTION
After fix:
- On K8s platform with `ClusterIP` service type:
  - Invocation URL: always "URL not exposed"
  - Test button: always enabled (unless function is not running, etc.)
  - `x-nuclio-invoke-via` request header: `domain-name`
- On K8s platform with `NodePort` service type and on non-K8s platform:
  - Invocation URL:
    - comprises of external IP address and port number in case they are valid
    - "URL not exposed" otherwise
  - Test button:
    - enabled in case external IP address and port number are valid
    - dsiabled otherwise (and when function is not running, etc.)
  - `x-nuclio-invoke-via` request header: `external-ip`

Breaking change:
`nclFunctionEventPane` component now calls `invokeFunction` with 3 parameters instead of 2: `eventData`, `invokeVia`, & `canceler`.