### PR TITLE
[Nuclio] Configuration: label must not begin with nuclio.io/

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -171,7 +171,7 @@
     "NO_INTERNET_ACCESS": "No internet access",
     "NO_LOGS_HAVE_BEEN_FOUND": "No logs have been found...",
     "NORMAL": "Normal",
-    "NOT_START_WITH_FORBIDDEN_WORDS": "Must not start with 'kubernetes.io' or 'k8s.io'",
+    "NOT_START_WITH_FORBIDDEN_WORDS": "Must not start with 'kubernetes.io', 'k8s.io' or 'nuclio.io'",
     "NOT_YET_DEPLOYED": "Not yet deployed",
     "OAUTH2": "OAuth2",
     "ONBUILD_IMAGE": "Onbuild image",

--- a/src/igz_controls/services/validation.service.js
+++ b/src/igz_controls/services/validation.service.js
@@ -264,7 +264,7 @@
                     name: 'prefixNotStart',
                     label: '[' + $i18next.t('functions:PREFIX', { lng: lng }) + '] ' +
                         $i18next.t('functions:NOT_START_WITH_FORBIDDEN_WORDS', { lng: lng }),
-                    pattern: /^(?!kubernetes\.io\/)(?!k8s\.io\/)/
+                    pattern: /^(?!kubernetes\.io\/)(?!k8s\.io\/)(?!nuclio\.io\/)/
                 },
                 {
                     name: 'prefixMaxLength',


### PR DESCRIPTION
https://trello.com/c/Je8VwqwT/574-nuclio-configuration-label-must-not-begin-with-nuclioio

Function › Configuration › Labels: added 'nuclio.io' as an invalid prefix:
![image](https://user-images.githubusercontent.com/13918850/98027521-7a4dd600-1e15-11eb-89c3-f3982ead7ff8.png)
