### PR TITLE
Impl [Nuclio] Default HTTP trigger: init name to `http`, reword

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -134,7 +134,7 @@
     "HOST": "Host",
     "HOST_PATH": "Host path",
     "HUGE": "Huge",
-    "HTTP_TRIGGER_MSG": "You currently didn’t add an HTTP trigger. If you deploy the function without specifying one, Nuclio will add it automatically on deploy with a default configuration. If you want to configure the HTTP trigger differently —&nbsp;<a class=\"link\" data-ng-click=\"$ctrl.addDefaultHttpTrigger()\">add it here</a>&nbsp;and edit it.",
+    "HTTP_TRIGGER_MSG": "A Nuclio function must have a single HTTP trigger. You can define such a trigger&nbsp;<a class=\"link\" data-ng-click=\"$ctrl.addDefaultHttpTrigger($event)\">here</a>. Otherwise, when deploying the function a default HTTP trigger named \"default-http\" is defined and deployed automatically unless there is a custom HTTP trigger configuration in the <a class=\"link\" data-ui-sref=\"app.project.function.edit.code\">external source code</a>.",
     "HTTP_TRIGGER_NAME_DESCRIPTION": "If the name of the HTTP trigger is <b>default-http</b> it might get overridden by a remote function specification configured in <b>Code Entry Type.</b>",
     "IMAGE_NAME": "Image name",
     "IMAGE_NAME_DESCRIPTION": "The name of the built container image (default for this function: <b>{{defaultImageName}}</b>)",

--- a/src/igz_controls/components/validating-input-field/validating-input-field.less
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.less
@@ -171,7 +171,7 @@
 
         .validation-pop-up {
             position: absolute;
-            width: 260px;
+            width: 280px;
             border-radius: 3px;
             opacity: 1;
             box-shadow: @validation-pop-up-box-shadow;

--- a/src/nuclio/common/components/collapsing-row/collapsing-row.component.js
+++ b/src/nuclio/common/components/collapsing-row/collapsing-row.component.js
@@ -21,7 +21,6 @@
         var lng = i18next.language;
 
         ctrl.actions = [];
-        ctrl.isEditModeActive = false;
 
         ctrl.$onInit = onInit;
 

--- a/src/nuclio/common/services/version-helper.service.js
+++ b/src/nuclio/common/services/version-helper.service.js
@@ -29,7 +29,7 @@
 
                 if (!lodash.isEmpty(ingress)) {
                     return {
-                        text: ingress.host,
+                        text: 'http://' + ingress.host,
                         valid: true
                     };
                 }


### PR DESCRIPTION
- Reword message when no HTTP trigger exists
  ![image](https://user-images.githubusercontent.com/13918850/98348656-b3f32c80-2021-11eb-908b-22ba32cd4043.png)
- Fix: HTTP trigger name's more-info tooltip missing on init and appears only after trigger item is expanded then collapsed.
  ![image](https://user-images.githubusercontent.com/13918850/98348680-bd7c9480-2021-11eb-99fc-8dc015e7b610.png)
  ![image](https://user-images.githubusercontent.com/13918850/98348695-c2414880-2021-11eb-85d0-bc6773635216.png)
- When using the link in the above message to add a new HTTP trigger:
  - Set its name `http` instead of value from backend (`default-http`).
  - Start in edit mode of trigger (expanded with input fields).
  - Disable the Deploy button (until trigger item is applied validly).
  ![image](https://user-images.githubusercontent.com/13918850/98348738-cec5a100-2021-11eb-9339-39a92667587b.png)