### PR TITLE
[API gateways] Hide when on non-K8s platform

### DIFF
--- a/src/igz_controls/components/navigation-tabs/navigation-tabs.service.js
+++ b/src/igz_controls/components/navigation-tabs/navigation-tabs.service.js
@@ -4,7 +4,7 @@
     angular.module('iguazio.dashboard-controls')
         .factory('NavigationTabsService', NavigationTabsService);
 
-    function NavigationTabsService($i18next, i18next, lodash, ConfigService) {
+    function NavigationTabsService($timeout, $i18next, i18next, lodash, ConfigService, FunctionsService) {
         return {
             getNavigationTabsConfig: getNavigationTabsConfig
         };
@@ -53,12 +53,17 @@
                     {
                         tabName: $i18next.t('common:FUNCTIONS', {lng: lng}),
                         uiRoute: 'app.project.functions',
-                    },
-                    {
-                        tabName: $i18next.t('functions:API_GATEWAYS', {lng: lng}),
-                        uiRoute: 'app.project.api-gateways',
                     }
                 ];
+
+                $timeout(function () {
+                    if (FunctionsService.isKubePlatform()) {
+                        config.push({
+                            tabName: $i18next.t('functions:API_GATEWAYS', {lng: lng}),
+                            uiRoute: 'app.project.api-gateways',
+                        });
+                    }
+                });
             }
 
             return config;


### PR DESCRIPTION
https://trello.com/c/5oxL4wOU/576-api-gateways-hide-when-on-non-k8s-platform

On K8s:
![image](https://user-images.githubusercontent.com/13918850/98702442-0b2b3100-2383-11eb-8d4b-dc7fb6afd7d2.png)
![image](https://user-images.githubusercontent.com/13918850/98702445-0cf4f480-2383-11eb-8b22-61769c75dcc0.png)

On non-K8s:
![image](https://user-images.githubusercontent.com/13918850/98702462-10887b80-2383-11eb-8f5c-5b182e2e0046.png)
