### PR TITLE
[Nuclio] Configuration: allow modify labels on non-K8s

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.component.js
@@ -12,8 +12,9 @@
         });
 
     function NclVersionConfigurationLabelsController($element, $i18next, $rootScope, $timeout, i18next, lodash,
-                                                     FormValidationService, PreventDropdownCutOffService,
-                                                     ValidationService, VersionHelperService) {
+                                                     FormValidationService, FunctionsService,
+                                                     PreventDropdownCutOffService, ValidationService,
+                                                     VersionHelperService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -21,6 +22,7 @@
             maxElementsCount: 10,
             childrenSelector: '.table-body'
         };
+        ctrl.isKubePlatform = false;
         ctrl.labelsForm = null;
         ctrl.scrollConfig = {
             axis: 'y',
@@ -55,6 +57,7 @@
 
         ctrl.addNewLabel = addNewLabel;
         ctrl.handleAction = handleAction;
+        ctrl.isLabelsDisabled = isLabelsDisabled;
         ctrl.onChangeData = onChangeData;
 
         //
@@ -65,6 +68,8 @@
          * Post linking method
          */
         function postLink() {
+            ctrl.isKubePlatform = FunctionsService.isKubePlatform();
+
 
             // Bind DOM-related preventDropdownCutOff method to component's controller
             PreventDropdownCutOffService.preventDropdownCutOff($element, '.three-dot-menu');
@@ -103,7 +108,7 @@
                         ctrl.labelsForm.$setSubmitted();
                         $rootScope.$broadcast('change-state-deploy-button', {component: 'label', isDisabled: true});
                     }
-                })
+                });
             }
         }
 
@@ -116,7 +121,7 @@
          */
         function addNewLabel(event) {
             // prevent adding labels for deployed functions
-            if (ctrl.isVersionDeployed(ctrl.version)) {
+            if (ctrl.isLabelsDisabled()) {
                 return;
             }
 
@@ -151,6 +156,14 @@
                     updateLabels();
                 });
             }
+        }
+
+        /**
+         * Checks if labels should be disabled
+         * @returns {boolean}
+         */
+        function isLabelsDisabled() {
+            return ctrl.isKubePlatform && ctrl.isVersionDeployed(ctrl.version);
         }
 
         /**

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.tpl.html
@@ -32,19 +32,19 @@
                                      data-item-index="$index"
                                      data-use-type="false"
                                      data-validation-rules="$ctrl.validationRules"
-                                     data-is-disabled="$ctrl.isVersionDeployed($ctrl.version)"
+                                     data-is-disabled="$ctrl.isLabelsDisabled()"
                                      data-action-handler-callback="$ctrl.handleAction(actionType, index)"
                                      data-change-data-callback="$ctrl.onChangeData(newData, index)"
                                      data-submit-on-fly="true"
-                                     data-key-tooltip="$ctrl.addNewLabelTooltip"
-                                     data-value-tooltip="$ctrl.addNewLabelTooltip">
+                                     data-key-tooltip="$ctrl.isLabelsDisabled() ? $ctrl.addNewLabelTooltip : ''"
+                                     data-value-tooltip="$ctrl.isLabelsDisabled() ? $ctrl.addNewLabelTooltip : ''">
                 </ncl-key-value-input>
             </div>
         </div>
         <div class="igz-create-button create-label-button"
-             data-ng-class="{'disabled': $ctrl.isVersionDeployed($ctrl.version)}"
+             data-ng-class="{'disabled': $ctrl.isLabelsDisabled()}"
              data-ng-click="$ctrl.addNewLabel($event)"
-             data-uib-tooltip="{{$ctrl.addNewLabelTooltip}}"
+             data-uib-tooltip="{{$ctrl.isLabelsDisabled() ? $ctrl.addNewLabelTooltip : ''}}"
              data-tooltip-append-to-body="true"
              data-tooltip-placement="right"
              data-tooltip-popup-delay="100">


### PR DESCRIPTION
https://trello.com/c/YYghX2Zf/575-nuclio-configuration-allow-modify-labels-on-non-k8s

- Function › Configuration › Labels: disabled on edit only for K8s platform
  - On K8s platform:
    ![image](https://user-images.githubusercontent.com/13918850/98818833-c19b1e80-2434-11eb-988a-12870c247baa.png)
  - On non-K8s platform:
    ![image](https://user-images.githubusercontent.com/13918850/98818850-c8299600-2434-11eb-8a09-a28834fbaba8.png)