### PR TITLE
[API GWs] Wizard: add Host field when none provided from BE

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -83,6 +83,7 @@
     "EDIT_FUNCTION_EVENT": "Edit function event",
     "EDIT_PROJECT": "Edit Project",
     "ENDPOINT": "Endpoint",
+    "ENTER_HOST_TO_SEE_ENDPOINT": "Enter host to see endpoint",
     "ENVIRONMENT_VARIABLES": "Environment Variables",
     "ERROR_MSG": {
         "COULD_NOT_READ_FILE": "Could not read file...",

--- a/src/nuclio/api-gateways/api-gateways.service.js
+++ b/src/nuclio/api-gateways/api-gateways.service.js
@@ -68,20 +68,22 @@
          */
         function buildIngressHost(apiGateway, project) {
             var ingressHostTemplate = lodash.get(ConfigService, 'nuclio.ingressHostTemplate', '');
-            var namespace = lodash.get(ConfigService, 'nuclio.namespace', '');
-            var name = lodash.get(apiGateway, 'spec.name', '');
-            var projectName = lodash.get(project, 'metadata.name', '');
-            var path = lodash.get(apiGateway, 'spec.path', '');
 
-            var host = lodash.trimEnd(
-                ingressHostTemplate
-                    .replace(/{{\s\.ResourceName\s}}/, name)
-                    .replace(/{{\s\.ProjectName\s}}/, projectName)
-                    .replace(/{{\s\.Namespace\s}}/, namespace),
-                '/'
-            );
+            if (!lodash.isEmpty(ingressHostTemplate)) {
+                var namespace = lodash.get(ConfigService, 'nuclio.namespace', '');
+                var name = lodash.get(apiGateway, 'spec.name', '');
+                var projectName = lodash.get(project, 'metadata.name', '');
 
-            lodash.set(apiGateway, 'spec.host', host);
+                var host = lodash.trimEnd(
+                    ingressHostTemplate
+                        .replace(/{{\s\.ResourceName\s}}/, name)
+                        .replace(/{{\s\.ProjectName\s}}/, projectName)
+                        .replace(/{{\s\.Namespace\s}}/, namespace),
+                    '/'
+                );
+
+                lodash.set(apiGateway, 'spec.host', host);
+            }
 
             self.buildEndpoint(apiGateway);
         }

--- a/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
+++ b/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
@@ -1,3 +1,4 @@
+/* eslint max-statements: ["error", 60] */
 (function () {
     'use strict';
 
@@ -19,7 +20,7 @@
         });
 
     function NewApiGatewayWizardController($q, $scope, $rootScope, $timeout, $i18next, i18next, lodash, ngDialog,
-                                           ApiGatewaysService, DialogsService, ValidationService) {
+                                           ApiGatewaysService, ConfigService, DialogsService, ValidationService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -65,8 +66,11 @@
         };
         ctrl.usernameIsFocused = false;
         ctrl.validationRules = {
-            apiGatewayName: ValidationService.getValidationRules('apiGateway.name')
+            apiGatewayName: ValidationService.getValidationRules('apiGateway.name'),
+            host: ValidationService.getValidationRules('k8s.dns1123Subdomain')
         };
+
+        ctrl.nuclioConfigData = ConfigService.nuclio;
 
         ctrl.$onInit = onInit;
 

--- a/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.tpl.html
+++ b/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.tpl.html
@@ -144,6 +144,26 @@
                                 </div>
                             </div>
 
+                            <div class="field-wrapper host-field"
+                                 data-ng-if="!$ctrl.nuclioConfigData.ingressHostTemplate">
+                                <div class="field-label asterisk">{{ 'functions:HOST' | i18next }}</div>
+
+                                <div class="field-input">
+                                    <igz-validating-input-field class="api-gateway-host"
+                                                                data-test-id="api-gateways.wizard_host.input"
+                                                                data-field-type="input"
+                                                                data-input-name="host"
+                                                                data-input-value="$ctrl.apiGateway.spec.host"
+                                                                data-placeholder-text="s-u-b.domain.com"
+                                                                data-form-object="$ctrl.apiGatewayForm"
+                                                                data-validation-is-required="true"
+                                                                data-validation-rules="$ctrl.validationRules.host"
+                                                                data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                                data-update-data-field="spec.host">
+                                    </igz-validating-input-field>
+                                </div>
+                            </div>
+
                             <div class="field-wrapper path-field">
                                 <div class="field-label">{{ 'common:PATH' | i18next }}</div>
 
@@ -163,7 +183,8 @@
 
                             <div class="end-point-block">
                                 <div class="end-point-title">{{ 'functions:ENDPOINT' | i18next }}</div>
-                                <div class="end-point-host">
+                                <div class="end-point-host"
+                                     data-ng-if="$ctrl.apiGateway.spec.host && $ctrl.apiGateway.ui.endpoint">
                                     <div class="host"
                                          data-test-id="api-gateways.wizard_endpoint.text">{{ $ctrl.apiGateway.ui.endpoint }}</div>
                                     <div class="copy-to-clipboard igz-action-panel">
@@ -173,6 +194,9 @@
                                             </igz-copy-to-clipboard>
                                         </div>
                                     </div>
+                                </div>
+                                <div data-ng-if="!$ctrl.apiGateway.spec.host || !$ctrl.apiGateway.ui.endpoint">
+                                    {{ 'functions:ENTER_HOST_TO_SEE_ENDPOINT' | i18next }}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
https://trello.com/c/MXh9iCUc/586-api-gws-wizard-add-host-field-when-none-provided-from-be

- Project › API gateways › wizard › Basic Settings: when on non-K8s platform, when there is no default HTTP host-ingress template from backend, added a new “Host” field, which, together with “Path” field, constructs “Endpoint” (when “Host” is empty “Enter host to see endpoint” message appears and the copy-to-clipboard icon button is hidden):
  ![image](https://user-images.githubusercontent.com/13918850/99179844-ed1a5380-2729-11eb-9867-af7254da1331.png)
  ![image](https://user-images.githubusercontent.com/13918850/99179848-f2779e00-2729-11eb-9129-432bbc15eaa6.png)
