### PR TITLE
[Nuclio] Configuration>Security context: validation & order

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
@@ -44,6 +44,7 @@
         ctrl.$onChanges = onChanges;
 
         ctrl.isDemoMode = ConfigService.isDemoMode;
+        ctrl.lodash = lodash;
         ctrl.validationRules = {
             integer: ValidationService.getValidationRules('integer')
         };
@@ -78,6 +79,12 @@
                 });
 
                 ctrl.enableFunction = !lodash.get(ctrl.version, 'spec.disable', false);
+
+                $timeout(function () {
+                    if (ctrl.basicSettingsForm.$invalid) {
+                        ctrl.basicSettingsForm.$setSubmitted();
+                    }
+                });
             }
         }
 
@@ -93,19 +100,18 @@
         function inputValueCallback(newData, field) {
             lodash.set(ctrl, field, lodash.includes(field, 'timeout') ? Number(newData) : newData);
 
+            if (lodash.includes(field, 'timeout')) {
+                lodash.set(ctrl.version, 'spec.timeoutSeconds', ctrl.timeout.min * 60 + ctrl.timeout.sec);
+            } else if (lodash.startsWith(field, 'spec.securityContext.') && newData === '') {
+                lodash.unset(ctrl.version, field);
+            } else {
+                lodash.set(ctrl.version, field, newData);
+            }
+
+            ctrl.basicSettingsForm.$setSubmitted();
+            ctrl.onChangeCallback();
+
             $timeout(function () {
-                if (ctrl.basicSettingsForm.$valid) {
-                    if (lodash.includes(field, 'timeout')) {
-                        lodash.set(ctrl.version, 'spec.timeoutSeconds', ctrl.timeout.min * 60 + ctrl.timeout.sec);
-                    } else if (lodash.startsWith(field, 'spec.securityContext.') && newData === '') {
-                        lodash.unset(ctrl.version, field);
-                    } else {
-                        lodash.set(ctrl.version, field, newData);
-                    }
-
-                    ctrl.onChangeCallback();
-                }
-
                 $rootScope.$broadcast('change-state-deploy-button', {
                     component: 'settings',
                     isDisabled: !ctrl.basicSettingsForm.$valid

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.tpl.html
@@ -77,25 +77,15 @@
             </div>
         </div>
         <div class="row">
-            <div class="fs-group-block">
-                <div class="label">{{ 'common:FS_GROUP' | i18next }}</div>
-                <igz-number-input data-allow-empty-field="true"
-                                  data-value-step="1"
-                                  data-min-value="0"
-                                  data-max-value="4294967295"
-                                  data-form-object="$ctrl.basicSettingsForm"
-                                  data-input-name="fs_group"
-                                  data-update-number-input-callback="$ctrl.inputValueCallback(newData, field)"
-                                  data-update-number-input-field="spec.securityContext.fsGroup"
-                                  data-current-value="$ctrl.version.spec.securityContext.fsGroup">
-                </igz-number-input>
-            </div>
             <div class="run-as-user-block">
-                <div class="label">{{ 'common:RUN_AS_USER' | i18next }}</div>
+                <div class="label" data-ng-class="{asterisk: $ctrl.version.spec.securityContext.runAsGroup}">
+                    {{ 'common:RUN_AS_USER' | i18next }}
+                </div>
                 <igz-number-input data-allow-empty-field="true"
+                                  data-validation-is-required="$ctrl.lodash.isNumber($ctrl.version.spec.securityContext.runAsGroup)"
                                   data-value-step="1"
                                   data-min-value="0"
-                                  data-max-value="4294967295"
+                                  data-max-value="2147483647"
                                   data-form-object="$ctrl.basicSettingsForm"
                                   data-input-name="run_as_user"
                                   data-update-number-input-callback="$ctrl.inputValueCallback(newData, field)"
@@ -108,12 +98,25 @@
                 <igz-number-input data-allow-empty-field="true"
                                   data-value-step="1"
                                   data-min-value="0"
-                                  data-max-value="4294967295"
+                                  data-max-value="2147483647"
                                   data-form-object="$ctrl.basicSettingsForm"
                                   data-input-name="run_as_group"
                                   data-update-number-input-callback="$ctrl.inputValueCallback(newData, field)"
                                   data-update-number-input-field="spec.securityContext.runAsGroup"
                                   data-current-value="$ctrl.version.spec.securityContext.runAsGroup">
+                </igz-number-input>
+            </div>
+            <div class="fs-group-block">
+                <div class="label">{{ 'common:FS_GROUP' | i18next }}</div>
+                <igz-number-input data-allow-empty-field="true"
+                                  data-value-step="1"
+                                  data-min-value="0"
+                                  data-max-value="2147483647"
+                                  data-form-object="$ctrl.basicSettingsForm"
+                                  data-input-name="fs_group"
+                                  data-update-number-input-callback="$ctrl.inputValueCallback(newData, field)"
+                                  data-update-number-input-field="spec.securityContext.fsGroup"
+                                  data-current-value="$ctrl.version.spec.securityContext.fsGroup">
                 </igz-number-input>
             </div>
         </div>


### PR DESCRIPTION
1. Put “Run as user” first, “Run as group” second, and “FS Group” last.
2. Made “Run as user” mandatory when “Run as group” is not empty.
3. Set the maximum value for all three fields to 2147483647.

![image](https://user-images.githubusercontent.com/13918850/99900660-a42e4600-2cb9-11eb-9473-cb7c2cad42fb.png)

https://trello.com/c/j6Blp5tR/569-nuclio-configurationsecurity-context-validation-order