### PR TITLE
Impl [Nuclio] Use consistent orange color for building status

### DIFF
--- a/src/nuclio/common/components/navigation-tabs/navigation-tabs.less
+++ b/src/nuclio/common/components/navigation-tabs/navigation-tabs.less
@@ -60,7 +60,7 @@ ncl-navigation-tabs {
                     }
 
                     &.ncl-status-building {
-                        background-color: @sunflower-yellow;
+                        background-color: @pale-orange;
                     }
 
                     &.ncl-status-error {
@@ -103,10 +103,10 @@ ncl-navigation-tabs {
 
                         &.ncl-status-tooltip-building {
                             padding-left: 10px;
-                            background-color: @sunflower-yellow;
+                            background-color: @pale-orange;
 
                             &:after {
-                                border-right-color: @sunflower-yellow;
+                                border-right-color: @pale-orange;
                             }
                         }
 


### PR DESCRIPTION
- Function: use the same orange color for “Building” state in the “Status” tab header as the orange color used in the project‘s “Functions” screen in “Status” list
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/99910943-cb0c6c80-2cf9-11eb-83ad-032a67d69f13.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/99910947-cf388a00-2cf9-11eb-9a4a-b7e41f69f0f2.png)