### PR TITLE
[Nuclio] Function: Inform about UI precedence over external

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -31,6 +31,7 @@
     "CLICK_TO_DISABLE": "Click to disable",
     "CLICK_TO_ENABLE": "Click to enable",
     "CODE_ENTRY_TYPE": "Code entry type",
+    "CODE_ENTRY_TYPE_NOTE": "<b>Note:&nbsp</b>The UI configuration is merged with the external-code configuration (if exists) with precedence to the UI configuration.",
     "COLLAPSE_ALL": "Collapse all",
     "CONFIG_MAP": "Config map",
     "CONFIG_MAP_NAME": "Config map name",

--- a/src/nuclio/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/functions/version/version-code/version-code.tpl.html
@@ -95,6 +95,7 @@
                                 </igz-validating-input-field>
                             </div>
                         </div>
+                        <div class="code-entry-row" data-ng-i18next="[html]functions:CODE_ENTRY_TYPE_NOTE"></div>
                     </div>
 
                     <div data-ng-if="$ctrl.selectedEntryType.id === 'image'"


### PR DESCRIPTION
https://trello.com/c/V6RTV0tz/601-nuclio-function-inform-about-ui-precedence-over-external

- Function › Code › Code Entry Type: when any option is selected other than “Source code (edit online)” a message is displayed to inform the user that the configuration in UI has precedence over the configuration in the external code source.
  ![image](https://user-images.githubusercontent.com/13918850/100009791-fbc2d380-2dd7-11eb-83a5-03c5aaf03ac1.png)