### PR TITLE
[Nuclio] Allow overriding when a newer version exists

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -181,6 +181,7 @@
     "ONBUILD_IMAGE_DESCRIPTION": "The name of an \"onbuild\" container image from which to build the function's processor image; the name can include {{ .Label }} and {{ .Arch }} for formatting",
     "OVERRIDE": "Override",
     "OVERWRITE": "Overwrite",
+    "OVERWRITE_FUNCTION_MESSAGE": "A newer version of the function is already deployed. Deploying your version will overwrite the newer version. Alternatively, cancel the deployment, refresh the UI to get the latest version, make your changes again, and redeploy.",
     "PATH_DESCRIPTION": "A relative directory path within the data container",
     "PERSISTENT_VOLUME_CLAIM_NAME": "Persistent Volume Claim Name",
     "PLACEHOLDER": {

--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -12,7 +12,8 @@
             initFunctionActions: initFunctionActions,
             initVersionActions: initVersionActions,
             isKubePlatform: isKubePlatform,
-            openFunctionConflictDialog: openFunctionConflictDialog
+            openFunctionConflictDialog: openFunctionConflictDialog,
+            openVersionOverwriteDialog: openVersionOverwriteDialog
         };
 
         return self;
@@ -935,6 +936,29 @@
                     className: 'ngdialog-theme-nuclio'
                 });
             }
+        }
+
+        /**
+         * Show pop-up with cancel button and overwrite function button
+         * @returns {Promise}
+         */
+        function openVersionOverwriteDialog() {
+            var lng = i18next.language;
+            var message = $i18next.t('functions:OVERWRITE_FUNCTION_MESSAGE', { lng: lng });
+            var cancelButtonCaption = $i18next.t('common:CANCEL', { lng: lng });
+            var overrideButtonCaption = $i18next.t('common:OVERWRITE', { lng: lng });
+
+            return ngDialog.openConfirm({
+                template: '<div class="title">' + message + '</div>' +
+                    '<div class="close-button igz-icon-close" data-ng-click="closeThisDialog()"></div>' +
+                    '<div class="buttons">' +
+                    '<button class="ncl-secondary-button igz-button-just-text" data-ng-click="closeThisDialog()" >' +
+                    cancelButtonCaption + '</button>' +
+                    '<button class="ncl-primary-button igz-button-primary" data-ng-click="confirm(allowOverwrite)">' +
+                    overrideButtonCaption + '</button></div>',
+                plain: true,
+                className: 'ngdialog-theme-iguazio alert-dialog'
+            });
         }
     }
 }());


### PR DESCRIPTION
https://trello.com/c/vTnCBo6v/598-nuclio-allow-overriding-when-a-newer-version-exists

- Function: on deploying a function, in case there is already a newer version deployed, show a pop-up explaining the situation and suggest to overwrite the newer version with the current stale one (“Cancel” button is focused by default):
  ![image](https://user-images.githubusercontent.com/13918850/100546614-ff88a700-326a-11eb-950f-ddb4f1b38bed.png)