### PR TITLE
[Nuclio] Actions remain disabled after deploy cancel/fail

### DIFF
--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -252,6 +252,9 @@
                             FunctionsService.openVersionOverwriteDialog()
                                 .then(function () {
                                     deployButtonClick(event, lodash.omit(ctrl.version, ['metadata.resourceVersion']));
+                                })
+                                .catch(function () {
+                                    ctrl.isFunctionDeployed = true;
                                 });
                         } else {
                             DialogsService.alert(lodash.get(error, 'data.error', defaultMsg));


### PR DESCRIPTION
https://trello.com/c/uggBEfAM/610-nuclio-actions-remain-disabled-after-deploy-cancel-fail

- Function: [bugfix] Refresh and Actions remained disabled after the “Deploy” button was click and deploy was canceled or failed
  ![image](https://user-images.githubusercontent.com/13918850/100740107-d427c880-33e0-11eb-878e-17550094ce7d.png)