### PR TITLE
Impl [Build] HTML: Collapse consecutive spaces into 1, not 0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,8 @@ gulp.task('app.js', function () {
         .pipe(minifyHtml({
             removeComments: true,
             collapseWhitespace: true,
-            collapseInlineTagWhitespace: true
+            collapseInlineTagWhitespace: true,
+            conservativeCollapse: true
         }))
         .pipe(ngHtml2Js({
             moduleName: config.app_files.templates_module_name

--- a/src/nuclio/common/components/collapsing-row/collapsing-row.tpl.html
+++ b/src/nuclio/common/components/collapsing-row/collapsing-row.tpl.html
@@ -86,8 +86,8 @@
                         <span class="field-label">{{ 'functions:CONFIG_MAP_NAME' | i18next }}</span>:&nbsp;{{ $ctrl.item.volume.configMap.name }};&nbsp;
                     </span>
                     <span data-ng-if="!$ctrl.isNil($ctrl.item.volume.persistentVolumeClaim.claimName)">
-                        <span class="field-label">{{ 'functions:PERSISTENT_VOLUME_CLAIM_NAME' | i18next }}</span>:
-                        &nbsp;{{ $ctrl.item.volume.persistentVolumeClaim.claimName }};&nbsp;
+                        <span class="field-label">{{ 'functions:PERSISTENT_VOLUME_CLAIM_NAME' | i18next }}</span>:&nbsp;
+                        {{ $ctrl.item.volume.persistentVolumeClaim.claimName }};&nbsp;
                     </span>
 
                     <!-- Worker Allocator name -->


### PR DESCRIPTION
For example:

The source code
```html
<foo>   
  <bar>
```
would turn to
```html
<foo> <bar>
```
instead of
```html
<foo><bar>
```