### PR TITLE
[Nuclio] Configuration: remove "FS group" field on K8s

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
@@ -12,7 +12,8 @@
         });
 
     function NclVersionConfigurationBasicSettingsController($rootScope, $timeout, $i18next, i18next, lodash,
-                                                            ConfigService, DialogsService, ValidationService) {
+                                                            ConfigService, DialogsService, FunctionsService,
+                                                            ValidationService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -41,6 +42,7 @@
             }
         ];
 
+        ctrl.$onInit = onInit;
         ctrl.$onChanges = onChanges;
 
         ctrl.isDemoMode = ConfigService.isDemoMode;
@@ -56,6 +58,13 @@
         //
         // Hook methods
         //
+
+        /**
+         * Initialization method
+         */
+        function onInit() {
+            ctrl.platformIsKube = FunctionsService.isKubePlatform();
+        }
 
         /**
          * On changes hook method.

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.tpl.html
@@ -106,7 +106,7 @@
                                   data-current-value="$ctrl.version.spec.securityContext.runAsGroup">
                 </igz-number-input>
             </div>
-            <div class="fs-group-block">
+            <div class="fs-group-block" data-ng-if="!$ctrl.platformIsKube">
                 <div class="label">{{ 'common:FS_GROUP' | i18next }}</div>
                 <igz-number-input data-allow-empty-field="true"
                                   data-value-step="1"


### PR DESCRIPTION
https://trello.com/c/NtLIQ5xL/617-nuclio-configuration-remove-fs-group-field-on-k8s

- Function › Configuration: Remove “FS Group” field when on K8s platform
  - K8s platform:
  ![image](https://user-images.githubusercontent.com/13918850/101680787-e1405980-3a69-11eb-8f91-f380a74b0088.png)
  - Non-K8s platform:
  ![image](https://user-images.githubusercontent.com/13918850/101680830-f1583900-3a69-11eb-9b71-52d78355adfc.png)