### PR TITLE
Impl [igzMoreInfo] Do not let tooltip be obstructed

### DIFF
--- a/src/igz_controls/components/more-info/more-info.less
+++ b/src/igz_controls/components/more-info/more-info.less
@@ -20,7 +20,7 @@
                 color: @icon-help-round-hover-before-color;
             }
 
-            + .row-description {
+            + .row-description-wrapper.row-description {
                 color: @icon-help-description-hover-color;
             }
         }
@@ -42,13 +42,19 @@
             cursor: pointer;
         }
 
-        &+ .row-description {
+        &+ .row-description-wrapper {
             display: none;
         }
 
-        &:not(.click-trigger):hover + .row-description, &.open + .row-description {
+        &:not(.click-trigger):hover + .row-description-wrapper,
+        &.open + .row-description-wrapper {
             display: block;
         }
+    }
+
+    .row-description-wrapper {
+        position: fixed;
+        z-index: 4;
     }
 
     .row-description {
@@ -64,7 +70,6 @@
         font-weight: 400;
         white-space: pre-line;
         line-height: normal;
-        z-index: 9999;
 
         &::before {
             position: absolute;
@@ -99,7 +104,7 @@
         &.top,
         &.top-left,
         &.top-right {
-            bottom: calc(100% + 8px);
+            bottom: 35px;
 
             &::before {
                 .triangle-arrow(down; @row-description-triangle-color; 8px; 10px);
@@ -111,7 +116,7 @@
         &.bottom,
         &.bottom-left,
         &.bottom-right {
-            top: calc(100% + 8px);
+            top: 8px;
 
             &::before {
                 .triangle-arrow(up; @row-description-triangle-color; 8px; 10px);
@@ -122,7 +127,7 @@
 
         &.right,
         &.left {
-            top: calc(50% - 20px);
+            top: -30px;
 
             &::before {
                 top: 7px;

--- a/src/igz_controls/components/more-info/more-info.tpl.html
+++ b/src/igz_controls/components/more-info/more-info.tpl.html
@@ -10,15 +10,17 @@
              data-ng-click="$ctrl.handleQuestionMarkClick($event)"
              class="question-mark">
         </div>
-        <div class="row-description"
-             data-ng-if="$ctrl.isHtmlEnabled"
-             data-ng-class="$ctrl.defaultTooltipPlacement"
-             data-ng-bind-html="$ctrl.description">
-        </div>
-        <div class="row-description"
-             data-ng-if="!$ctrl.isHtmlEnabled"
-             data-ng-class="$ctrl.defaultTooltipPlacement">
-            {{$ctrl.description}}
+        <div class="row-description-wrapper">
+            <div class="row-description"
+                 data-ng-if="$ctrl.isHtmlEnabled"
+                 data-ng-class="$ctrl.defaultTooltipPlacement"
+                 data-ng-bind-html="$ctrl.description">
+            </div>
+            <div class="row-description"
+                 data-ng-if="!$ctrl.isHtmlEnabled"
+                 data-ng-class="$ctrl.defaultTooltipPlacement">
+                {{$ctrl.description}}
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
- `igzMoreInfo`: prevent tooltip be obstructed by different UI elements (as a result of CSS rule `overflow: hidden`).
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/102108756-f76c6200-3e3b-11eb-9a28-a9b244713d86.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/102108773-fdfad980-3e3b-11eb-97e5-24fe2abf7e87.png)