### PR TITLE
Impl [Nuclio] N/A invocation URL for not running, not only error

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -343,7 +343,7 @@
         },
         "STOP_FUNCTION": "Stop function",
         "TARGET_CPU": "Applicable only when minimum and maximum number of replicas are not empty, are not equal to each other, and the maximum is greater than 1",
-        "TO_MAKE_FUNCTION_ACCESSIBLE": "To make the function accessible outside of the cluster, go to the <a class=\"link\" data-ui-sref=\"app.project.function.edit.triggers( {functionId:'{{functionId}}' })\" >Triggers</a> tab and configure an HTTP trigger with an ingress",
+        "TO_MAKE_FUNCTION_ACCESSIBLE": "To make the function accessible outside of the cluster, go to the <a class=\"link\" data-ui-sref=\"app.project.function.edit.triggers({functionId:'{{functionId}}'})\">Triggers</a> tab and configure an HTTP trigger with an ingress",
         "URL": "A URL for downloading the archive file",
         "USED_BY_API_GATEWAY": "Used by API gateway: \"{{apiGatewayName}}\"",
         "V3IO": "A directory in an Iguazio Data Science Platform data container",

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -73,7 +73,6 @@
         ctrl.getTooltip = getTooltip;
         ctrl.handleAction = handleAction;
         ctrl.isFunctionShowed = isFunctionShowed;
-        ctrl.isIngressInvalid = isIngressInvalid;
         ctrl.onFireAction = onFireAction;
         ctrl.onSelectRow = onSelectRow;
         ctrl.toggleFunctionRow = toggleFunctionRow;
@@ -179,14 +178,6 @@
          */
         function isFunctionShowed() {
             return ctrl.function.ui.isShowed;
-        }
-
-        /**
-         * Checks if Ingress is invalid
-         * @returns {boolean}
-         */
-        function isIngressInvalid() {
-            return VersionHelperService.isIngressInvalid(lodash.find(ctrl.function.spec.triggers, ['kind', 'http']));
         }
 
         /**

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.spec.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.spec.js
@@ -83,14 +83,6 @@ describe('nclFunctionCollapsingRow component:', function () {
         });
     });
 
-    describe('isIngressInvalid(): ', function () {
-        it('should call VersionHelperService.isIngressInvalid() method', function () {
-            spyOn(VersionHelperService, 'isIngressInvalid');
-            ctrl.isIngressInvalid();
-            expect(VersionHelperService.isIngressInvalid).toHaveBeenCalled();
-        });
-    });
-
     describe('getTooltip(): ', function () {
         it('should gets correct tooltip regarding function status', function () {
             ctrl.function.spec.disable = true;

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.less
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.less
@@ -52,11 +52,6 @@
                         height: 36px;
                         width: 56px;
                     }
-
-                    .actions-more-info {
-                        position: fixed;
-                        z-index: 10;
-                    }
                 }
             }
         }

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.tpl.html
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.tpl.html
@@ -80,12 +80,10 @@
                         <igz-copy-to-clipboard data-value="$ctrl.invocationUrl.text"></igz-copy-to-clipboard>
                     </div>
                 </div>
-                <div class="igz-action-panel invocation-tooltip" data-ng-if="!$ctrl.invocationUrl.valid &&
-                $ctrl.isIngressInvalid() && !$ctrl.lodash.startsWith($ctrl.lodash.get($ctrl.function, 'status.state'),'error')">
+                <div class="igz-action-panel invocation-tooltip" data-ng-if="$ctrl.invocationUrl.info">
                     <div class="actions-more-info">
                         <igz-more-info
-                                data-description="{{ 'functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE' |
-                                i18next:{functionId: $ctrl.function.metadata.name} }}"
+                                data-description="{{ 'functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE' | i18next:{functionId: $ctrl.function.metadata.name} }}"
                                 data-is-html-enabled="true"
                                 data-trigger="click">
                         </igz-more-info>

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
@@ -22,8 +22,7 @@
         });
 
     function NclFunctionVersionRowController($state, $i18next, i18next, lodash, ActionCheckboxAllService,
-                                             ConfigService, FunctionsService, NuclioHeaderService, TableSizeService,
-                                             VersionHelperService) {
+                                             ConfigService, FunctionsService, NuclioHeaderService, TableSizeService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -43,7 +42,6 @@
         ctrl.$onInit = onInit;
         ctrl.$onDestroy = onDestroy;
 
-        ctrl.isIngressInvalid = isIngressInvalid;
         ctrl.onFireAction = onFireAction;
         ctrl.onSelectRow = onSelectRow;
         ctrl.onToggleFunctionState = onToggleFunctionState;
@@ -92,14 +90,6 @@
         //
         // Public methods
         //
-
-        /**
-         * Checks if Ingress is invalid
-         * @returns {boolean}
-         */
-        function isIngressInvalid() {
-            return VersionHelperService.isIngressInvalid(lodash.find(ctrl.function.spec.triggers, ['kind', 'http']));
-        }
 
         /**
          * According to given action name calls proper action handler

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.spec.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.spec.js
@@ -82,14 +82,6 @@ describe('nclFunctionVersionRow component:', function () {
         });
     });
 
-    describe('isIngressInvalid(): ', function () {
-        it('should call VersionHelperService.isIngressInvalid() method', function () {
-            spyOn(VersionHelperService, 'isIngressInvalid');
-            ctrl.isIngressInvalid();
-            expect(VersionHelperService.isIngressInvalid).toHaveBeenCalled();
-        });
-    });
-
     describe('onFireAction(): ', function () {
         it('should call actionHandlerCallback() method', function () {
             spyOn(ctrl, 'actionHandlerCallback');

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.less
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.less
@@ -54,11 +54,6 @@
                         height: 36px;
                         width: 56px;
                     }
-
-                    .actions-more-info {
-                        position: fixed;
-                        z-index: 10;
-                    }
                 }
             }
 

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.tpl.html
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.tpl.html
@@ -44,12 +44,10 @@
                     <igz-copy-to-clipboard data-value="$ctrl.invocationUrl.text"></igz-copy-to-clipboard>
                 </div>
             </div>
-            <div class="igz-action-panel invocation-tooltip" data-ng-if="!$ctrl.invocationUrl.valid &&
-             $ctrl.isIngressInvalid() && !$ctrl.lodash.startsWith($ctrl.lodash.get($ctrl.function, 'status.state'),'error')">
+            <div class="igz-action-panel invocation-tooltip" data-ng-if="$ctrl.invocationUrl.info">
                 <div class="actions-more-info">
                     <igz-more-info
-                            data-description="{{ 'functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE' |
-                            i18next:{functionId: $ctrl.function.metadata.name} }}"
+                            data-description="{{ 'functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE' | i18next:{functionId: $ctrl.function.metadata.name} }}"
                             data-is-html-enabled="true"
                             data-trigger="click">
                     </igz-more-info>

--- a/src/nuclio/functions/version/version-monitoring/version-monitoring.component.js
+++ b/src/nuclio/functions/version/version-monitoring/version-monitoring.component.js
@@ -10,7 +10,7 @@
             controller: NclVersionMonitoringController
         });
 
-    function NclVersionMonitoringController($rootScope, $scope, $timeout, lodash, ConfigService, VersionHelperService) {
+    function NclVersionMonitoringController($rootScope, $scope, $timeout, lodash, ConfigService) {
         var ctrl = this;
 
         ctrl.versionStatus = {};
@@ -33,7 +33,6 @@
         ctrl.$onInit = onInit;
 
         ctrl.checkIsErrorState = checkIsErrorState;
-        ctrl.isIngressInvalid = isIngressInvalid;
         ctrl.onRowCollapse = onRowCollapse;
 
         ctrl.isDemoMode = ConfigService.isDemoMode;
@@ -62,14 +61,6 @@
          */
         function checkIsErrorState() {
             return lodash.includes(['error', 'unhealthy'], lodash.get(ctrl.versionStatus, 'state'));
-        }
-
-        /**
-         * Checks if Ingress is invalid
-         * @returns {boolean}
-         */
-        function isIngressInvalid() {
-            return VersionHelperService.isIngressInvalid(lodash.find(ctrl.version.spec.triggers, ['kind', 'http']));
         }
 
         /**

--- a/src/nuclio/functions/version/version-monitoring/version-monitoring.tpl.html
+++ b/src/nuclio/functions/version/version-monitoring/version-monitoring.tpl.html
@@ -23,10 +23,8 @@
                           class="monitoring-invocation-field-invalid">
                             {{$ctrl.version.ui.invocationUrl.text}}
                             <igz-more-info
-                                    data-ng-if="$ctrl.isIngressInvalid() &&
-                                    !$ctrl.lodash.startsWith($ctrl.lodash.get($ctrl.version, 'status.state'),'error')"
-                                    data-description="{{ 'functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE' |
-                                    i18next:{functionId: $ctrl.version.metadata.name} }}"
+                                    data-ng-if="$ctrl.version.ui.invocationUrl.info"
+                                    data-description="{{ 'functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE' | i18next:{functionId: $ctrl.version.metadata.name} }}"
                                     data-is-html-enabled="true"
                                     data-trigger="click">
                             </igz-more-info>


### PR DESCRIPTION
Previously “N/A” was displayed for “Invocation URL” when `status.state` is `'error'`. Now it is displayed whenever the function is not running, i.e. `status.state` is not `'ready'`, or it is but `spec.disable` is `true`.