### PR TITLE
[Triggers] HTTP ingress path must start with a slash

### DIFF
--- a/src/igz_controls/services/validation.service.js
+++ b/src/igz_controls/services/validation.service.js
@@ -371,6 +371,9 @@
                     generateRule.beginEndWith('0-9'),
                     generateRule.noConsecutiveCharacters(',-')
                 ],
+                ingressHostPath: [
+                    generateRule.beginWith('/')
+                ],
                 interval: [
                     {
                         name: 'validCharacters',

--- a/src/nuclio/functions/version/version-triggers/version-triggers.component.js
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.component.js
@@ -30,7 +30,8 @@
         ctrl.validationRules = {
             arrayInt: ValidationService.getValidationRules('function.arrayInt'),
             host: {
-                key: ValidationService.getValidationRules('k8s.dns1123Subdomain')
+                key: ValidationService.getValidationRules('k8s.dns1123Subdomain'),
+                value: ValidationService.getValidationRules('function.ingressHostPath')
             },
             itemName: ValidationService.getValidationRules('function.triggerName', [{
                 name: 'uniqueness',


### PR DESCRIPTION
https://trello.com/c/8Lbkhc9e/628-triggers-http-ingress-path-must-start-with-a-slash

- Function › Triggers › HTTP › Ingresses › Path: enforce value to start with `/`
  ![image](https://user-images.githubusercontent.com/13918850/102719098-a43f5700-42f4-11eb-81c7-55a207aeefcf.png)