### PR TITLE
Impl [Nuclio] Pass project from parent instead of fetch async-ly

### DIFF
--- a/src/nuclio/api-gateways/api-gateways.component.js
+++ b/src/nuclio/api-gateways/api-gateways.component.js
@@ -10,22 +10,21 @@
                 getApiGateway: '&',
                 getApiGateways: '&',
                 getFunctions: '&',
-                getProject: '&',
+                project: '<',
                 updateApiGateway: '&'
             },
             templateUrl: 'nuclio/api-gateways/api-gateways.tpl.html',
             controller: ApiGatewaysController
         });
 
-    function ApiGatewaysController($interval, $q, $rootScope, $scope, $state, $stateParams, $timeout, $i18next,
-                                   i18next, lodash, ngDialog, ApiGatewaysService, CommonTableService, ConfigService,
-                                   DialogsService, GeneralDataService, NuclioHeaderService) {
+    function ApiGatewaysController($interval, $q, $rootScope, $scope, $state, $timeout, $i18next, i18next, lodash,
+                                   ngDialog, ApiGatewaysService, CommonTableService, ConfigService, DialogsService,
+                                   GeneralDataService, NuclioHeaderService) {
         var ctrl = this;
         var lng = i18next.language;
 
         var POLL_TIMEOUT_DELAY_MILLIS = 300000;
 
-        var title = {}; // breadcrumbs config
         var pollingCancelDeferred = null;
         var pollingTimeout = null;
         var updatingInterval = null;
@@ -101,6 +100,16 @@
             $scope.$on('action-panel_fire-action', onFireAction);
             $scope.$on('action-checkbox-all_checked-items-count-change', updatePanelActions);
             $scope.$on('action-checkbox-all_check-all', updatePanelActions);
+
+            $timeout(function () {
+                // update breadcrumbs
+                var title = {
+                    project: ctrl.project,
+                    tab: $i18next.t('functions:API_GATEWAYS', { lng: lng })
+                };
+
+                NuclioHeaderService.updateMainHeader('common:PROJECTS', title, $state.current.name);
+            });
         }
 
         /**
@@ -344,16 +353,7 @@
          * Initializes API Gateways list
          */
         function initApiGateways() {
-            ctrl.getProject({projectId: $stateParams.projectId})
-                .then(function (project) {
-                    ctrl.project = project;
-                    title.project = project;
-                    title.tab = $i18next.t('functions:API_GATEWAYS', { lng: lng });
-
-                    NuclioHeaderService.updateMainHeader('common:PROJECTS', title, $state.current.name);
-
-                    return ctrl.refreshApiGateways();
-                })
+            return ctrl.refreshApiGateways()
                 .then(function () {
                     startAutoUpdate();
                 })

--- a/src/nuclio/common/components/breadcrumbs/breadcrumbs.component.js
+++ b/src/nuclio/common/components/breadcrumbs/breadcrumbs.component.js
@@ -87,7 +87,7 @@
             var toState = transition.$to();
 
             // Check to exclude prototypical inheritance of the `mainHeaderTitle` property from parent router state
-            if (Object.prototype.hasOwnProperty.call(toState.data, 'mainHeaderTitle')) {
+            if (lodash.has(toState.data, 'mainHeaderTitle')) {
 
                 ctrl.mainHeaderTitle = {
                     title: toState.data.mainHeaderTitle

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -22,7 +22,7 @@
 
     function NclFunctionCollapsingRowController($interval, $state, $i18next, i18next, lodash, ngDialog,
                                                 ActionCheckboxAllService, ConfigService, DialogsService,
-                                                ExportService, FunctionsService, NuclioHeaderService, TableSizeService,
+                                                ExportService, FunctionsService, TableSizeService,
                                                 VersionHelperService) {
         var ctrl = this;
 
@@ -158,8 +158,8 @@
          * @returns {string} - tooltip
          */
         function getTooltip() {
-            return ctrl.function.spec.disable ? $i18next.t('functions:TOOLTIP.RUN_FUNCTION', {lng: lng}) :
-                $i18next.t('functions:TOOLTIP.STOP_FUNCTION', {lng: lng});
+            return ctrl.function.spec.disable ? $i18next.t('functions:TOOLTIP.RUN_FUNCTION', { lng: lng }) :
+                $i18next.t('functions:TOOLTIP.STOP_FUNCTION', { lng: lng });
         }
 
         /**
@@ -194,8 +194,10 @@
          * @param {string} state - absolute state name or relative state path
          */
         function onSelectRow(event, state) {
-            if (lodash.isNil(event.target.closest('.igz-action-item')) &&
-                lodash.isNil(event.target.closest('.actions-more-info'))) {
+            if (
+                lodash.isNil(event.target.closest('.igz-action-item')) &&
+                lodash.isNil(event.target.closest('.actions-more-info'))
+            ) {
                 if (!angular.isString(state)) {
                     state = 'app.project.function.edit.code';
                 }
@@ -209,8 +211,6 @@
                     functionId: ctrl.function.metadata.name,
                     projectNamespace: ctrl.project.metadata.namespace
                 });
-
-                NuclioHeaderService.updateMainHeader('common:PROJECTS', ctrl.title, $state.current.name);
             }
         }
 
@@ -237,7 +237,8 @@
             event.stopPropagation();
 
             if (!ctrl.function.spec.disable && !lodash.isEmpty(apiGateways)) {
-                DialogsService.alert($i18next.t('functions:ERROR_MSG.DISABLE_API_GW_FUNCTION', {lng: lng, apiGatewayName: apiGateways[0]}));
+                DialogsService.alert($i18next.t('functions:ERROR_MSG.DISABLE_API_GW_FUNCTION',
+                                                { lng: lng, apiGatewayName: apiGateways[0] }));
             } else if (!ctrl.function.spec.disable) {
                 disableFunction();
             } else {
@@ -282,7 +283,7 @@
                         lodash.remove(ctrl.functionsList, ['metadata.name', ctrl.function.metadata.name]);
                     })
                     .catch(function (error) {
-                        var defaultMsg = $i18next.t('functions:ERROR_MSG.DELETE_FUNCTION', {lng: lng});
+                        var defaultMsg = $i18next.t('functions:ERROR_MSG.DELETE_FUNCTION', { lng: lng });
 
                         if (error.status === 409) {
                             FunctionsService.openVersionDeleteDialog()
@@ -382,14 +383,15 @@
         function initFunctionActions() {
             ctrl.functionActions = angular.copy(FunctionsService.initFunctionActions());
 
-            var deleteAction = lodash.find(ctrl.functionActions, {'id': 'delete'});
+            var deleteAction = lodash.find(ctrl.functionActions, { id: 'delete' });
 
             if (!lodash.isNil(deleteAction) && lodash.isEmpty(apiGateways)) {
                 deleteAction.confirm = {
-                    message: $i18next.t('functions:DELETE_FUNCTION', {lng: lng}) + ' “' + ctrl.function.metadata.name + '”?',
-                    description: $i18next.t('functions:DELETE_FUNCTION_DESCRIPTION', {lng: lng}),
-                    yesLabel: $i18next.t('common:YES_DELETE', {lng: lng}),
-                    noLabel: $i18next.t('common:CANCEL', {lng: lng}),
+                    message: $i18next.t('functions:DELETE_FUNCTION', { lng: lng }) + ' “' +
+                        ctrl.function.metadata.name + '”?',
+                    description: $i18next.t('functions:DELETE_FUNCTION_DESCRIPTION', { lng: lng }),
+                    yesLabel: $i18next.t('common:YES_DELETE', { lng: lng }),
+                    noLabel: $i18next.t('common:CANCEL', { lng: lng }),
                     type: 'nuclio_alert'
                 }
             }
@@ -414,7 +416,7 @@
                         }
                     })
                     .catch(function (error) {
-                        var defaultMsg = $i18next.t('functions:ERROR_MSG.GET_FUNCTION', {lng: lng});
+                        var defaultMsg = $i18next.t('functions:ERROR_MSG.GET_FUNCTION', { lng: lng });
 
                         terminateInterval();
                         convertStatusState();
@@ -458,7 +460,7 @@
             // set `nuclio.io/project-name` label to relate this function to its project
             lodash.set(functionCopy, ['metadata', 'labels', 'nuclio.io/project-name'], ctrl.project.metadata.name);
 
-            ctrl.updateFunction({'function': functionCopy, projectID: ctrl.project.metadata.name})
+            ctrl.updateFunction({ 'function': functionCopy, projectID: ctrl.project.metadata.name })
                 .then(function () {
                     tempFunctionCopy = null;
 
@@ -467,7 +469,7 @@
                 .catch(function (error) {
                     ctrl.function = tempFunctionCopy;
 
-                    var defaultMsg = $i18next.t('functions:ERROR_MSG.UPDATE_FUNCTION', {lng: lng});
+                    var defaultMsg = $i18next.t('functions:ERROR_MSG.UPDATE_FUNCTION', { lng: lng });
 
                     return DialogsService.alert(lodash.get(error, 'data.error', defaultMsg));
                 })

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.spec.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.spec.js
@@ -131,12 +131,10 @@ describe('nclFunctionCollapsingRow component:', function () {
             Object.defineProperty(event, 'target', {writable: false, value: {closest: angular.noop}});
 
             spyOn($state, 'go');
-            spyOn(NuclioHeaderService, 'updateMainHeader');
 
             ctrl.onSelectRow(event);
 
             expect($state.go).toHaveBeenCalled();
-            expect(NuclioHeaderService.updateMainHeader).toHaveBeenCalled();
         });
     });
 

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
@@ -1,4 +1,3 @@
-/* eslint max-statements: ["error", 100] */
 (function () {
     'use strict';
 
@@ -21,8 +20,8 @@
             controller: NclFunctionVersionRowController
         });
 
-    function NclFunctionVersionRowController($state, $i18next, i18next, lodash, ActionCheckboxAllService,
-                                             ConfigService, FunctionsService, NuclioHeaderService, TableSizeService) {
+    function NclFunctionVersionRowController($state, $i18next, i18next, lodash, ActionCheckboxAllService, ConfigService,
+                                             FunctionsService, TableSizeService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -96,7 +95,7 @@
          * @param {string} actionType - a type of action
          */
         function onFireAction(actionType) {
-            ctrl.actionHandlerCallback({actionType: actionType, checkedItems: [ctrl.version]});
+            ctrl.actionHandlerCallback({ actionType: actionType, checkedItems: [ctrl.version] });
         }
 
         /**
@@ -105,8 +104,10 @@
          * @param {string} state - absolute state name or relative state path
          */
         function onSelectRow(event, state) {
-            if (lodash.isNil(event.target.closest('.igz-action-item')) &&
-                lodash.isNil(event.target.closest('.actions-more-info'))) {
+            if (
+                lodash.isNil(event.target.closest('.igz-action-item')) &&
+                lodash.isNil(event.target.closest('.actions-more-info'))
+            ) {
                 if (!angular.isString(state)) {
                     state = 'app.project.function.edit.code';
                 }
@@ -120,8 +121,6 @@
                     functionId: ctrl.function.metadata.name,
                     projectNamespace: ctrl.project.metadata.namespace
                 });
-
-                NuclioHeaderService.updateMainHeader('common:PROJECTS', ctrl.title, $state.current.name);
             }
         }
 
@@ -130,7 +129,7 @@
          * @param {MouseEvent} event
          */
         function onToggleFunctionState(event) {
-            ctrl.toggleFunctionState({event: event})
+            ctrl.toggleFunctionState({ event: event })
         }
 
         //
@@ -161,10 +160,11 @@
         function initVersionActions() {
             ctrl.versionActions = angular.copy(FunctionsService.initVersionActions());
 
-            var deleteAction = lodash.find(ctrl.versionActions, {'id': 'delete'});
+            var deleteAction = lodash.find(ctrl.versionActions, { id: 'delete' });
 
             if (!lodash.isNil(deleteAction)) {
-                deleteAction.confirm.message = $i18next.t('functions:DELETE_VERSION', {lng: lng}) + ' “' + ctrl.version.name + '”?'
+                deleteAction.confirm.message = $i18next.t('functions:DELETE_VERSION', { lng: lng }) + ' “' +
+                    ctrl.version.name + '”?'
             }
         }
     }

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.spec.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.spec.js
@@ -99,12 +99,10 @@ describe('nclFunctionVersionRow component:', function () {
             Object.defineProperty(event, 'target', {writable: false, value: {closest: angular.noop}});
 
             spyOn($state, 'go');
-            spyOn(NuclioHeaderService, 'updateMainHeader');
 
             ctrl.onSelectRow(event);
 
             expect($state.go).toHaveBeenCalled();
-            expect(NuclioHeaderService.updateMainHeader).toHaveBeenCalled();
         });
     });
 

--- a/src/nuclio/functions/functions.component.spec.js
+++ b/src/nuclio/functions/functions.component.spec.js
@@ -72,7 +72,7 @@ describe('nclFunctions component: ', function () {
             ];
 
             var bindings = {
-                getProject: $q.when.bind($q),
+                project: project,
                 getFunctions: $q.when.bind($q),
             };
             var element = angular.element('<ncl-functions></ncl-functions>');
@@ -99,19 +99,15 @@ describe('nclFunctions component: ', function () {
 
     describe('$onInit(): ', function () {
         it('should initialize functions array', function () {
-            spyOn(ctrl, 'getProject').and.returnValue($q.when(project));
             spyOn(ctrl, 'refreshFunctions').and.callThrough();
             spyOn(ctrl, 'getFunctions').and.returnValue($q.when(functions));
 
-            ctrl.project = project;
             ctrl.functions = [];
 
             ctrl.$onInit();
             $rootScope.$digest();
             $timeout.flush();
 
-            expect(ctrl.getProject).toHaveBeenCalled();
-            expect(ctrl.project).toEqual(project);
             expect(ctrl.refreshFunctions).toHaveBeenCalled();
             expect(ctrl.getFunctions).toHaveBeenCalled();
             expect(ctrl.functions).toEqual(functions);
@@ -253,7 +249,6 @@ describe('nclFunctions component: ', function () {
     describe('refreshFunctions(): ', function () {
         it('should initialize functions list', function () {
             spyOn(ctrl, 'getFunctions').and.returnValue($q.when(functions));
-            ctrl.project = project;
             ctrl.functions = [];
 
             ctrl.refreshFunctions();

--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -10,7 +10,6 @@
                 containers: '<',
                 createVersion: '&',
                 deleteFunction: '&',
-                getProject: '&',
                 getFunction: '&',
                 getFunctions: '&',
                 onEditCallback: '&?',
@@ -83,49 +82,49 @@
             ctrl.actions = [
                 {
                     id: 'exportFunction',
-                    name: $i18next.t('functions:EXPORT_FUNCTION', {lng: lng})
+                    name: $i18next.t('functions:EXPORT_FUNCTION', { lng: lng })
                 },
                 {
                     id: 'deleteFunction',
-                    name: $i18next.t('functions:DELETE_FUNCTION', {lng: lng}),
+                    name: $i18next.t('functions:DELETE_FUNCTION', { lng: lng }),
                     dialog: {
                         message: {
-                            message: $i18next.t('functions:DELETE_FUNCTION', {lng: lng}) + ' “' + ctrl.version.metadata.name + '”?',
-                            description: $i18next.t('functions:DELETE_FUNCTION_DESCRIPTION', {lng: lng})
+                            message: $i18next.t('functions:DELETE_FUNCTION', { lng: lng }) + ' “' + ctrl.version.metadata.name + '”?',
+                            description: $i18next.t('functions:DELETE_FUNCTION_DESCRIPTION', { lng: lng })
                         },
-                        yesLabel: $i18next.t('common:YES_DELETE', {lng: lng}),
-                        noLabel: $i18next.t('common:CANCEL', {lng: lng}),
+                        yesLabel: $i18next.t('common:YES_DELETE', { lng: lng }),
+                        noLabel: $i18next.t('common:CANCEL', { lng: lng }),
                         type: 'nuclio_alert'
                     }
                 },
                 {
                     id: 'duplicateFunction',
-                    name: $i18next.t('functions:DUPLICATE_FUNCTION', {lng: lng})
+                    name: $i18next.t('functions:DUPLICATE_FUNCTION', { lng: lng })
                 },
                 {
                     id: 'viewConfig',
-                    name: $i18next.t('functions:VIEW_YAML', {lng: lng})
+                    name: $i18next.t('functions:VIEW_YAML', { lng: lng })
                 }
             ];
 
             ctrl.navigationTabsConfig = [
                 {
-                    tabName: $i18next.t('common:CODE', {lng: lng}),
+                    tabName: $i18next.t('common:CODE', { lng: lng }),
                     id: 'code',
                     uiRoute: 'app.project.function.edit.code'
                 },
                 {
-                    tabName: $i18next.t('common:CONFIGURATION', {lng: lng}),
+                    tabName: $i18next.t('common:CONFIGURATION', { lng: lng }),
                     id: 'configuration',
                     uiRoute: 'app.project.function.edit.configuration'
                 },
                 {
-                    tabName: $i18next.t('common:TRIGGERS', {lng: lng}),
+                    tabName: $i18next.t('common:TRIGGERS', { lng: lng }),
                     id: 'triggers',
                     uiRoute: 'app.project.function.edit.triggers'
                 },
                 {
-                    tabName: $i18next.t('common:STATUS', {lng: lng}),
+                    tabName: $i18next.t('common:STATUS', { lng: lng }),
                     id: 'status',
                     uiRoute: 'app.project.function.edit.monitoring',
                     status: VersionHelperService.isVersionDeployed(ctrl.version) ? lodash.get(ctrl.version, 'status.state') :
@@ -135,28 +134,14 @@
 
             ctrl.requiredComponents = {};
 
-            ctrl.getProject({ id: $stateParams.projectId })
-                .then(function (response) {
+            // breadcrumbs config
+            var title = {
+                project: ctrl.project,
+                function: $stateParams.functionId,
+                version: '$LATEST'
+            };
 
-                    // set projects data
-                    ctrl.project = response;
-
-                    // breadcrumbs config
-                    var title = {
-                        project: ctrl.project,
-                        function: $stateParams.functionId,
-                        version: '$LATEST'
-                    };
-
-                    NuclioHeaderService.updateMainHeader('common:PROJECTS', title, $state.current.name);
-                })
-                .then(setIngressHost)
-                .then(setImageNamePrefixTemplate)
-                .catch(function (error) {
-                    var defaultMsg = $i18next.t('functions:ERROR_MSG.GET_PROJECT', {lng: lng});
-
-                    DialogsService.alert(lodash.get(error, 'data.error', defaultMsg));
-                });
+            NuclioHeaderService.updateMainHeader('common:PROJECTS', title, $state.current.name);
 
             $scope.$on('change-state-deploy-button', changeStateDeployButton);
 
@@ -204,8 +189,9 @@
                 }
             });
 
-            setInvocationUrl();
+            setImageNamePrefixTemplate();
             setIngressHost();
+            setInvocationUrl();
         }
 
         //
@@ -220,7 +206,7 @@
         function deployButtonClick(event, version) {
             if (!ctrl.isDeployDisabled) {
                 ctrl.isFunctionDeployed = false;
-                $rootScope.$broadcast('deploy-function-version', {event: event});
+                $rootScope.$broadcast('deploy-function-version', { event: event });
 
                 var versionCopy = lodash.omit(angular.isDefined(version) ? version : ctrl.version, ['status', 'ui']);
 
@@ -246,7 +232,7 @@
                         });
                     })
                     .catch(function (error) {
-                        var defaultMsg = $i18next.t('common:ERROR_MSG.UNKNOWN_ERROR', {lng: lng});
+                        var defaultMsg = $i18next.t('common:ERROR_MSG.UNKNOWN_ERROR', { lng: lng });
 
                         if (error.status === 409 && isVersionDeployed) {
                             FunctionsService.openVersionOverwriteDialog()
@@ -276,9 +262,9 @@
          * @returns {string}
          */
         function getDeployStatusState(state) {
-            return state === 'ready' ? $i18next.t('functions:SUCCESSFULLY_DEPLOYED', {lng: lng}) :
-                   state === 'error' ? $i18next.t('functions:FAILED_TO_DEPLOY', {lng: lng})      :
-                   /* else */          $i18next.t('functions:DEPLOYING', {lng: lng});
+            return state === 'ready' ? $i18next.t('functions:SUCCESSFULLY_DEPLOYED', { lng: lng }) :
+                   state === 'error' ? $i18next.t('functions:FAILED_TO_DEPLOY', { lng: lng })      :
+                   /* else */          $i18next.t('functions:DEPLOYING', { lng: lng });
         }
 
         /**
@@ -331,7 +317,8 @@
                             deleteFunction();
                         });
                 } else {
-                    DialogsService.alert($i18next.t('functions:ERROR_MSG.DELETE_API_GW_FUNCTION', {lng: lng, apiGatewayName: apiGateways[0]}));
+                    DialogsService.alert($i18next.t('functions:ERROR_MSG.DELETE_API_GW_FUNCTION',
+                                                    { lng: lng, apiGatewayName: apiGateways[0] }));
                 }
             } else if (item.id === 'exportFunction') {
                 ExportService.exportFunction(ctrl.version);
@@ -370,17 +357,18 @@
         function refreshFunction() {
             ctrl.isSplashShowed.value = true;
 
-            ctrl.getFunction({metadata: ctrl.version.metadata, projectID: lodash.get(ctrl.project, 'metadata.name')})
+            ctrl.getFunction({ metadata: ctrl.version.metadata, projectID: lodash.get(ctrl.project, 'metadata.name') })
                 .then(function (response) {
                     var versionUi = ctrl.version.ui;
                     ctrl.version = response;
                     ctrl.version.ui = versionUi;
 
-                    setInvocationUrl();
+                    setImageNamePrefixTemplate();
                     setIngressHost();
+                    setInvocationUrl();
                 })
                 .catch(function (error) {
-                    var defaultMsg = $i18next.t('functions:ERROR_MSG.GET_FUNCTION', {lng: lng});
+                    var defaultMsg = $i18next.t('functions:ERROR_MSG.GET_FUNCTION', { lng: lng });
 
                     DialogsService.alert(lodash.get(error, 'data.error', defaultMsg));
                 })
@@ -435,7 +423,7 @@
                     $state.go('app.project.functions');
                 })
                 .catch(function (error) {
-                    var defaultMsg = $i18next.t('functions:ERROR_MSG.DELETE_FUNCTION', {lng: lng});
+                    var defaultMsg = $i18next.t('functions:ERROR_MSG.DELETE_FUNCTION', { lng: lng });
 
                     if (error.status === 409) {
                         FunctionsService.openVersionDeleteDialog()
@@ -503,8 +491,9 @@
                                 versionChanged: false
                             });
 
-                            setInvocationUrl();
+                            setImageNamePrefixTemplate();
                             setIngressHost();
+                            setInvocationUrl();
 
                             ctrl.isFunctionDeployed = true;
                         }
@@ -582,14 +571,15 @@
          */
         function stateChangeStart(transition) {
             var toState = transition.$to();
-            if (lodash.get($state, 'params.functionId') !== transition.params('to').functionId &&
-                !VersionHelperService.isVersionDeployed(ctrl.version)) {
-
+            if (
+                lodash.get($state, 'params.functionId') !== transition.params('to').functionId &&
+                !VersionHelperService.isVersionDeployed(ctrl.version)
+            ) {
                 transition.abort();
 
-                DialogsService.confirm($i18next.t('common:LEAVE_PAGE_CONFIRM', {lng: lng}),
-                                       $i18next.t('common:LEAVE', {lng: lng}),
-                                       $i18next.t('common:DONT_LEAVE', {lng: lng}))
+                DialogsService.confirm($i18next.t('common:LEAVE_PAGE_CONFIRM', { lng: lng }),
+                                       $i18next.t('common:LEAVE', { lng: lng }),
+                                       $i18next.t('common:DONT_LEAVE', { lng: lng }))
                     .then(function () {
 
                         // unsubscribe from broadcast event


### PR DESCRIPTION
In `nclFunctions`, `nclApiGateways`, and `nclVersion` receive the project from their parent components via a new `project` one-way binding rather than receiving a `getProject` method binding and fetching the project asynchronously.