### PR TITLE
Impl [Nuclio] Function: Remove build image name prefix from field

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
@@ -44,6 +44,7 @@
         ctrl.maxLengths = {
             imageName: ValidationService.getMaxLength('function.imageName')
         };
+        ctrl.imageName = '';
 
         ctrl.$onInit = onInit;
         ctrl.$onChanges = onChanges;
@@ -87,10 +88,16 @@
                 ctrl.build.dependencies = lodash.get(ctrl.version, 'spec.build.dependencies', []).join('\n');
                 ctrl.build.runtimeAttributes.repositories = lodash.get(ctrl.version, 'spec.build.runtimeAttributes.repositories', []).join('\n');
 
+                ctrl.imageName = lodash.get(ctrl.version, 'spec.build.image');
+                var imageNamePrefix = ctrl.version.ui.imageNamePrefix;
+                if (!lodash.isEmpty(imageNamePrefix) && lodash.startsWith(ctrl.imageName, imageNamePrefix)) {
+                    ctrl.imageName = ctrl.imageName.replace(imageNamePrefix, '');
+                }
+
                 $timeout(function () {
                     if (ctrl.buildForm.$invalid) {
                         ctrl.buildForm.$setSubmitted();
-                        $rootScope.$broadcast('change-state-deploy-button', {component: 'build', isDisabled: true});
+                        $rootScope.$broadcast('change-state-deploy-button', { component: 'build', isDisabled: true });
                     }
                 });
             }
@@ -126,6 +133,11 @@
                     lodash.set(ctrl.build, field, newData);
                     lodash.set(ctrl.version, 'spec.build.' + field, commands);
                 }
+            } else if (field === 'imageName') {
+                var imageNamePrefix = ctrl.version.ui.imageNamePrefix;
+                var prefix = lodash.isEmpty(imageNamePrefix) ? '' : imageNamePrefix;
+                lodash.set(ctrl.version, 'spec.build.image', prefix + newData);
+                ctrl.imageName = newData;
             } else {
                 lodash.set(ctrl.version, field, newData);
             }
@@ -184,7 +196,7 @@
 
             Upload.upload({
                 url: '', // TODO
-                data: {file: file}
+                data: { file: file }
             }).then(function (response) { // on success
                 if (!uploadingData.uploaded && !lodash.isNil(response.config.data.file)) {
                     uploadingData.uploading = false;
@@ -235,13 +247,13 @@
             return [
                 {
                     id: 'script',
-                    label: $i18next.t('functions:SCRIPT', {lng: lng}),
+                    label: $i18next.t('functions:SCRIPT', { lng: lng }),
                     icon: 'ncl-icon-script',
                     active: true
                 },
                 {
                     id: 'file',
-                    label: $i18next.t('common:FILE', {lng: lng}),
+                    label: $i18next.t('common:FILE', { lng: lng }),
                     icon: 'ncl-icon-file',
                     active: true
                 }

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.spec.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.spec.js
@@ -45,6 +45,9 @@ describe('nclVersionConfigurationBuild component:', function () {
                    build: {
                        commands: ['1', '2']
                    }
+               },
+               ui: {
+                   imageNamePrefix: 'somePrefix'
                }
            };
 

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.tpl.html
@@ -26,12 +26,11 @@
                     <span class="flex-none">{{ $ctrl.version.ui.imageNamePrefix }}</span>
                     <igz-validating-input-field data-field-type="input"
                                                 data-input-name="imageName"
-                                                data-input-value="$ctrl.version.spec.build.image"
+                                                data-input-value="$ctrl.imageName"
                                                 data-is-focused="false"
                                                 data-form-object="$ctrl.buildForm"
                                                 data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_IMAGE_NAME' | i18next }}"
                                                 data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                data-update-data-field="spec.build.image"
                                                 data-validation-max-length="{{$ctrl.maxLengths.imageName}}"
                                                 data-validation-pattern="$ctrl.imageNameValidationPattern"
                                                 data-is-disabled="$ctrl.disabled"


### PR DESCRIPTION
- Function › Configuration › Build › Image: When the build image name (`spec.build.image`) includes the system's image-name prefix, split it so the prefix is only readonly to the left of the input field, and only the name itself is editable in the input field.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/102987947-dd0d4500-451b-11eb-8348-4a1b6a0aa354.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/102987937-d8e12780-451b-11eb-9451-71510836343b.png)

