### PR TITLE
Impl [Nuclio] DNS-1123 for name of function/API GW (was DNS-1035)

### DIFF
--- a/src/igz_controls/services/validation.service.js
+++ b/src/igz_controls/services/validation.service.js
@@ -258,6 +258,10 @@
                 generateRule.beginWith('a-z'),
                 generateRule.endWith('a-z 0-9')
             ],
+            dns1123Label: [
+                generateRule.validCharacters('a-z 0-9 -'),
+                generateRule.beginEndWith('a-z 0-9')
+            ],
             prefixedQualifiedName: [
                 {
                     name: 'nameValidCharacters',
@@ -311,11 +315,7 @@
                     generateRule.length({ max: lengths.k8s.configMapKey })
                 ],
                 dns1035Label: commonRules.dns1035Label.concat(generateRule.length({ max: lengths.k8s.dns1035Label })),
-                dns1123Label: [
-                    generateRule.validCharacters('a-z 0-9 -'),
-                    generateRule.beginEndWith('a-z 0-9'),
-                    generateRule.length({ max: lengths.k8s.dns1123Label })
-                ],
+                dns1123Label: commonRules.dns1123Label.concat(generateRule.length({ max: lengths.k8s.dns1123Label })),
                 dns1123Subdomain: [
                     generateRule.validCharacters('a-z 0-9 - .'),
                     generateRule.beginEndWith('a-z 0-9'),
@@ -352,7 +352,7 @@
                 ]
             },
             function: {
-                name: commonRules.dns1035Label.concat(
+                name: commonRules.dns1123Label.concat(
                     generateRule.mustNotBe('dashboard controller dlx scaler'),
                     generateRule.length({ max: lengths.function.name })
                 ),
@@ -399,7 +399,7 @@
                 ]
             },
             apiGateway: {
-                name: commonRules.dns1035Label.concat(
+                name: commonRules.dns1123Label.concat(
                     generateRule.mustNotBe('dashboard controller dlx scaler'),
                     generateRule.length({ max: lengths.apiGateway.name })
                 )


### PR DESCRIPTION
- Function: Changed restrictions for function and API gateway names from DNS-1035 label to DNS-1123 label. The only difference between a DNS-1123 label and a DNS-1035 label is that DNS-123 label can being with a digit while DNS-1035 cannot.
  ![image](https://user-images.githubusercontent.com/13918850/103239241-9f624f00-4955-11eb-82a3-ef9b139bf82e.png)
  ![image](https://user-images.githubusercontent.com/13918850/103239243-a12c1280-4955-11eb-9960-0df91f74a36a.png)