### PR TITLE
Impl [Nuclio] V3IO volume: turn Container Name optional

### DIFF
--- a/src/nuclio/common/components/edit-item/edit-item.tpl.html
+++ b/src/nuclio/common/components/edit-item/edit-item.tpl.html
@@ -93,7 +93,7 @@
             <div class="igz-col-45 attribute-field"
                  data-ng-if="!$ctrl.isNil($ctrl.item.volume.flexVolume.options.container)">
                 <div class="field-label">
-                    <span class="asterisk">{{ 'functions:CONTAINER_NAME' | i18next }}</span>
+                    <span>{{ 'functions:CONTAINER_NAME' | i18next }}</span>
                     <igz-more-info data-description="{{ 'functions:CONTAINER_NAME_DESCRIPTION' | i18next }}"
                                    data-trigger="click">
                     </igz-more-info>
@@ -103,7 +103,6 @@
                                             data-input-value="$ctrl.item.volume.flexVolume.options.container"
                                             data-is-focused="false"
                                             data-form-object="$ctrl.editItemForm"
-                                            data-validation-is-required="true"
                                             data-validation-rules="$ctrl.validationRules.containerName"
                                             data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_CONTAINER_NAME' | i18next }}"
                                             data-update-data-callback="$ctrl.inputValueCallback(newData, field)"


### PR DESCRIPTION
- Function › Configuration › Volumes: Turned “Container name” field of V3IO volume type optional
  ![image](https://user-images.githubusercontent.com/13918850/103239627-d08f4f00-4956-11eb-8a8a-f074feda01b5.png)