### PR TITLE
Fix [Nuclio] Actions remain disabled on deploy immediate error

### DIFF
--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -161,7 +161,7 @@
                 ctrl.isDeployResultShown = true;
                 ctrl.rowIsCollapsed.deployBlock = true;
 
-                pullFunctionState();
+                pollFunctionState();
             }
 
             ctrl.isLayoutCollapsed = true;
@@ -234,7 +234,7 @@
 
                 method({ version: versionCopy, projectId: ctrl.project.metadata.name })
                     .then(function () {
-                        pullFunctionState();
+                        pollFunctionState();
 
                         $timeout(function () {
                             $rootScope.$broadcast('igzWatchWindowResize::resize');
@@ -263,7 +263,9 @@
                             });
                             return deployButtonClick(event, version);
                         } else {
-                            return DialogsService.alert(lodash.get(error, 'data.error', defaultMsg));
+                            return DialogsService.alert(lodash.get(error, 'data.error', defaultMsg)).then(function () {
+                                ctrl.isFunctionDeployed = true;
+                            });
                         }
                     })
                     .finally(function () {
@@ -488,10 +490,10 @@
         }
 
         /**
-         * Pulls function status.
-         * Periodically sends request to get function's state, until state will not be 'ready' or 'error'
+         * Polls function status.
+         * Periodically sends request to get function's state, until state is steady.
          */
-        function pullFunctionState() {
+        function pollFunctionState() {
             ctrl.isDeployResultShown = true;
             lodash.set(ctrl.version, 'status.logs', []);
             setDeployResult('building');


### PR DESCRIPTION
- Function: [bugfix] Refresh and Actions remained disabled after the “Deploy” button was click and deploy was canceled or failed
  ![image](https://user-images.githubusercontent.com/13918850/100740107-d427c880-33e0-11eb-878e-17550094ce7d.png)

Relates to PR https://github.com/iguazio/dashboard-controls/pull/1140

Jira ticket 17889