### PR TITLE
Impl [Nuclio] Omit readiness timeout from request on empty field

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-build/version-configuration-build.component.js
@@ -139,7 +139,11 @@
                 lodash.set(ctrl.version, 'spec.build.image', prefix + newData);
                 ctrl.imageName = newData;
             } else {
-                lodash.set(ctrl.version, field, newData);
+                if (field === 'readinessTimeoutSeconds' && newData === '') {
+                    lodash.unset(ctrl.version, field);
+                } else {
+                    lodash.set(ctrl.version, field, newData);
+                }
             }
 
             $timeout(function () {


### PR DESCRIPTION
- Function › Configuration › Build › Readiness Timeout (seconds): when emptying the field — omit it entirely from the `POST`/`PUT` request’s JSON body (`spec.readinessTimeoutSeconds`) instead of setting it to an empty string.
  ![image](https://user-images.githubusercontent.com/13918850/104463926-079e6b00-55bb-11eb-98be-0ba77bd1b5b6.png)