### PR TITLE
Fix [DialogsService] Sequential confirmation dialogs not opening

### DIFF
--- a/src/igz_controls/services/dialogs.service.js
+++ b/src/igz_controls/services/dialogs.service.js
@@ -91,7 +91,7 @@
             return ngDialog.openConfirm({
                 template: template,
                 plain: true,
-                name: 'confirm',
+                name: 'confirm' + lodash.uniqueId(),
                 className: (type === 'nuclio_alert' ?
                     'ngdialog-theme-nuclio delete-entity-dialog-wrapper' : 'ngdialog-theme-iguazio') + ' confirm-dialog'
             });


### PR DESCRIPTION
Sometimes if the result of confirming a confirmation dialog should open another confirmation dialog, the latter dialog does not open because both dialogs are both named 'confirm' and the first one might not be entirely removed from the DOM before the new one should open.