### PR TITLE
Impl [Nuclio] Function: add unique classname to stale version msg

### DIFF
--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -994,7 +994,7 @@
                     '<button class="igz-button-primary" data-ng-click="confirm(allowOverwrite)">' +
                     overrideButtonCaption + '</button></div>',
                 plain: true,
-                className: 'ngdialog-theme-iguazio alert-dialog'
+                className: 'ngdialog-theme-iguazio alert-dialog function-deploy-stale'
             });
         }
 
@@ -1017,7 +1017,7 @@
                     '<button class="igz-button-remove" data-ng-click="confirm(allowDelete)">' +
                     overrideButtonCaption + '</button></div>',
                 plain: true,
-                className: 'ngdialog-theme-iguazio alert-dialog function-deploy-stale'
+                className: 'ngdialog-theme-iguazio alert-dialog function-delete-stale'
             });
         }
     }


### PR DESCRIPTION
- On deploy: `function-deploy-stale`
- On delete: `function-delete-stale`


Background: was originally implemented in PR https://github.com/iguazio/dashboard-controls/pull/1148 when only deploy flow was implemented, no delete flow yet.
Then delete flow was added in PR https://github.com/iguazio/dashboard-controls/pull/1152, and mistakenly moved `function-deploy-stale` to delete flow instead of leaving it in deploy flow. Also no classname was added to delete flow.

Now each flow has its own unique classname.