### PR TITLE
Fix [Nuclio] Functions: broken enabling/disabling messages

### DIFF
--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -319,7 +319,7 @@
 
             lodash.merge(ctrl.function, propertiesToDisableFunction);
 
-            updateFunction($i18next.t('COMMON:DISABLING', { lng: lng }) + '…');
+            updateFunction($i18next.t('common:DISABLING', { lng: lng }) + '…');
         }
 
         function duplicateFunction() {
@@ -360,7 +360,7 @@
 
             lodash.merge(ctrl.function, propertiesToEnableFunction);
 
-            updateFunction($i18next.t('COMMON:ENABLING', { lng: lng }) + '…');
+            updateFunction($i18next.t('common:ENABLING', { lng: lng }) + '…');
         }
 
         /**


### PR DESCRIPTION
- Functions: in “Status” column cells, the “Enabling…” and “Disabling…” messages are corrupted (ALL CAPS)
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/105062347-2c935200-5a83-11eb-922e-32d8340ab57e.png)
  ![image](https://user-images.githubusercontent.com/13918850/105062353-31580600-5a83-11eb-82e3-7bb3d044749d.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/105062377-34eb8d00-5a83-11eb-8830-afd5d7f3df23.png)
  ![image](https://user-images.githubusercontent.com/13918850/105062380-36b55080-5a83-11eb-8479-f5427017e8d4.png)
