### PR TITLE
Fix [Nuclio] Functions: start/stop: resource version not updating

### DIFF
--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -407,6 +407,11 @@
                             terminateInterval();
                             convertStatusState();
                             setStatusIcon();
+
+                            if (FunctionsService.isKubePlatform()) {
+                                var newResourceVersion = lodash.get(aFunction, 'metadata.resourceVersion');
+                                lodash.set(ctrl.function, 'metadata.resourceVersion', newResourceVersion);
+                            }
                         }
                     })
                     .catch(function (error) {


### PR DESCRIPTION
- Functions: [bugfix] resource version not updating when starting/stopping a function causing an unexpected error message when attempting to stop the function:
  ![image](https://user-images.githubusercontent.com/13918850/105063005-e985ae80-5a83-11eb-8228-da95bc3dbb07.png)