### PR TITLE
Fix [Nuclio] Function: Falsely displays error on disabling

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-basic-settings/version-configuration-basic-settings.component.js
@@ -143,8 +143,9 @@
          */
         function updateEnableStatus() {
             var apiGateways = lodash.get(ctrl.version, 'status.apiGateways', []);
+            var originallyDisabled = lodash.set(ctrl.version, 'spec.disable', false);
 
-            if (!lodash.isEmpty(apiGateways) && !ctrl.enableFunction) {
+            if (!lodash.isEmpty(apiGateways) && !ctrl.enableFunction && !originallyDisabled) {
                 DialogsService.alert($i18next.t('functions:ERROR_MSG.DISABLE_API_GW_FUNCTION', {
                     lng: lng,
                     apiGatewayName: apiGateways[0]


### PR DESCRIPTION
- Function › Configuration › Basic Settings › Enabled: When the function is currently disabled and is used by an API gateway, and the user checks the Enabled checkbox and then unchecks it, an error message is falsely displayed. It should not appear because the function was originally disabled. It should appear only when the function was originally enabled.
  ![image](https://user-images.githubusercontent.com/13918850/105068619-d37aec80-5a89-11eb-8bae-be26cb7160ea.png)
