### PR TITLE
[Browse] Table cell width is broken on window expanding

### DIFF
--- a/src/igz_controls/directives/resizable-table-column.directive.js
+++ b/src/igz_controls/directives/resizable-table-column.directive.js
@@ -243,7 +243,7 @@
                             columnWidth: ctrl.columnHeadWidth + 'px',
                             nextColumnWidth: ctrl.nextBlockWidth + 'px'
                         });
-                    });
+                    }, 200);
                 }
             }
 


### PR DESCRIPTION
https://trello.com/c/lphyqKXU/680-browse-table-cell-width-is-broken-on-window-expanding

After resizing the window to have small width, than expanding it, the columns are distorted:
![image](https://user-images.githubusercontent.com/13918850/105993425-130b8f00-60af-11eb-8b48-942c1d548a70.png)
