### PR TITLE
Impl [API GWs] Use consistent function status for display

### DIFF
--- a/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
+++ b/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
@@ -20,7 +20,8 @@
         });
 
     function NewApiGatewayWizardController($q, $scope, $rootScope, $timeout, $i18next, i18next, lodash, ngDialog,
-                                           ApiGatewaysService, ConfigService, DialogsService, ValidationService) {
+                                           ApiGatewaysService, ConfigService, DialogsService, FunctionsService,
+                                           ValidationService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -301,11 +302,11 @@
                 })
                 .map(function (aFunction) {
                     var name = lodash.get(aFunction, 'metadata.name');
-                    var state = lodash.get(aFunction, 'status.state');
+                    var status = FunctionsService.getDisplayStatus(aFunction);
                     return {
                         value: name,
                         label: name,
-                        additionalInfo: '(' + lodash.capitalize(state) + ')'
+                        additionalInfo: '(' + status + ')'
                     };
                 })
                 .value();


### PR DESCRIPTION
- API Gateways › Wizard › Function list:
  Instead of merely capitalizing the `status.state` of the function, such as:
  ![image](https://user-images.githubusercontent.com/13918850/106388079-7cf4a300-63e5-11eb-8a98-93a539215103.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388074-78c88580-63e5-11eb-9876-8c0a01d8cd7e.png)
  be consistent with the same set of values that is used throughout Nuclio for function status:
  ![image](https://user-images.githubusercontent.com/13918850/106388098-985fae00-63e5-11eb-8c95-6ebce37436f4.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388115-a57c9d00-63e5-11eb-8454-78f2c5c80a94.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388116-a7def700-63e5-11eb-9d41-84cb0b264237.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388119-aad9e780-63e5-11eb-93ef-ea8e21cde5ab.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388123-b0373200-63e5-11eb-9a6a-df3b126b251e.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388126-b62d1300-63e5-11eb-93c4-66ba9226e22a.png)
  ![image](https://user-images.githubusercontent.com/13918850/106388127-b9c09a00-63e5-11eb-9dc8-4e30055448ca.png)

Relates to PR https://github.com/iguazio/dashboard-controls/pull/1176