### PR TITLE
Impl [Nuclio] Remove runtime Python 2.7 and add 3.7 and 3.8

### DIFF
--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
@@ -202,14 +202,20 @@
                     visible: true
                 },
                 {
-                    id: 'python:2.7',
-                    name: 'Python 2.7',
+                    id: 'python:3.6',
+                    name: 'Python 3.6',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true
                 },
                 {
-                    id: 'python:3.6',
-                    name: 'Python 3.6',
+                    id: 'python:3.7',
+                    name: 'Python 3.7',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
+                    id: 'python:3.8',
+                    name: 'Python 3.8',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true
                 },

--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.spec.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.spec.js
@@ -26,14 +26,20 @@ describe('nclFunctionFromScratch Component:', function () {
                 visible: true
             },
             {
-                id: 'python:2.7',
-                name: 'Python 2.7',
+                id: 'python:3.6',
+                name: 'Python 3.6',
                 sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                 visible: true
             },
             {
-                id: 'python:3.6',
-                name: 'Python 3.6',
+                id: 'python:3.7',
+                name: 'Python 3.7',
+                sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                visible: true
+            },
+            {
+                id: 'python:3.8',
+                name: 'Python 3.8',
                 sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                 visible: true
             },

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
@@ -370,13 +370,18 @@
                     visible: true
                 },
                 {
-                    id: 'python:2.7',
-                    name: 'Python 2.7',
+                    id: 'python:3.6',
+                    name: 'Python 3.6',
                     visible: true
                 },
                 {
-                    id: 'python:3.6',
-                    name: 'Python 3.6',
+                    id: 'python:3.7',
+                    name: 'Python 3.7',
+                    visible: true
+                },
+                {
+                    id: 'python:3.8',
+                    name: 'Python 3.8',
                     visible: true
                 },
                 {

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -45,6 +45,8 @@
             'golang': 'Go',
             'python:2.7': 'Python 2.7',
             'python:3.6': 'Python 3.6',
+            'python:3.7': 'Python 3.7',
+            'python:3.8': 'Python 3.8',
             'dotnetcore': '.NET Core',
             'java': 'Java',
             'nodejs': 'NodeJS',

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
@@ -30,6 +30,8 @@
             'golang': 'Go',
             'python:2.7': 'Python 2.7',
             'python:3.6': 'Python 3.6',
+            'python:3.7': 'Python 3.7',
+            'python:3.8': 'Python 3.8',
             'dotnetcore': '.NET Core',
             'java': 'Java',
             'nodejs': 'NodeJS',

--- a/src/nuclio/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/functions/version/version-code/version-code.component.js
@@ -405,17 +405,25 @@
                     visible: true
                 },
                 {
-                    id: 'python:2.7',
+                    id: 'python:3.6',
                     ext: 'py',
-                    name: 'Python 2.7',
+                    name: 'Python 3.6',
                     language: 'python',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true
                 },
                 {
-                    id: 'python:3.6',
+                    id: 'python:3.7',
                     ext: 'py',
-                    name: 'Python 3.6',
+                    name: 'Python 3.7',
+                    language: 'python',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
+                    id: 'python:3.8',
+                    ext: 'py',
+                    name: 'Python 3.8',
                     language: 'python',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true


### PR DESCRIPTION
- Remove runtime “Python 2.7” and add runtimes “Python 3.7” and “Python 3.8”:
  - Create function › From template › Runtime filter
    ![image](https://user-images.githubusercontent.com/13918850/107384097-52e46480-6afa-11eb-89d0-cb6f8693e88f.png)
  - Create function › From scratch › Runtime field
    ![image](https://user-images.githubusercontent.com/13918850/107384166-5ed02680-6afa-11eb-90d3-9df8bc2309cd.png)
  - Function › Code › Runtime field
    ![image](https://user-images.githubusercontent.com/13918850/107384223-6c85ac00-6afa-11eb-869a-fc8fde94d899.png)
    ![image](https://user-images.githubusercontent.com/13918850/107384233-70193300-6afa-11eb-8089-f71d6c35af26.png)
  - Project › Functions (list) › Runtime (column)
    ![image](https://user-images.githubusercontent.com/13918850/107384363-8e7f2e80-6afa-11eb-9c8f-f74c74eac80f.png)

Relates to PRs https://github.com/nuclio/nuclio/pull/2065 & https://github.com/nuclio/nuclio/pull/2072