### PR TITLE
[Nuclio] Breadcrumbs dropdown: make wider and add tooltip

### DIFF
--- a/src/nuclio/common/components/breadcrumbs-dropdown/breadcrumbs-dropdown.less
+++ b/src/nuclio/common/components/breadcrumbs-dropdown/breadcrumbs-dropdown.less
@@ -39,7 +39,7 @@
         border: none;
         min-width: inherit;
         padding: 5px 0 8px;
-        width: 176px;
+        width: 230px;
         box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.25);
 
         .search-input {
@@ -56,7 +56,7 @@
             }
 
             input {
-                width: 160px;
+                width: 210px;
                 height: 32px;
                 border: solid 1px @pale-grey;
                 outline: none;
@@ -106,11 +106,11 @@
         li {
             height: 32px;
             line-height: 32px;
-            width: 192px;
+            width: 239px;
 
             .item-name {
                 display: inline-block;
-                width: 116px;
+                width: 170px;
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;

--- a/src/nuclio/common/components/breadcrumbs-dropdown/breadcrumbs-dropdown.tpl.html
+++ b/src/nuclio/common/components/breadcrumbs-dropdown/breadcrumbs-dropdown.tpl.html
@@ -14,7 +14,14 @@
         </div>
         <ul class="dropdown-list" data-ng-scrollbars>
             <li data-ng-repeat="item in $ctrl.itemsList | filter: $ctrl.searchText">
-                <a class="item-name" data-ng-click="$ctrl.showDetails($event, item)">{{item.name}}</a>
+                <a class="item-name"
+                   data-ng-click="$ctrl.showDetails($event, item)"
+                   data-uib-tooltip="{{item.name}}"
+                   data-tooltip-popup-delay="200"
+                   data-tooltip-append-to-body="true"
+                   data-tooltip-placement="top">
+                    {{item.name}}
+                </a>
                 <span class="igz-icon-tick" data-ng-show="$ctrl.title === item.name"></span>
             </li>
         </ul>


### PR DESCRIPTION
https://trello.com/c/D0egmD8w/686-nuclio-breadcrumbs-dropdown-make-wider-and-add-tooltip

- **Breadcrumbs**: Widened dropdown menu to allow about 10 more characters and add a tooltip with the value in full
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/107799369-fe452180-6d65-11eb-9ffb-bf55c28ab8c5.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/107799382-01d8a880-6d66-11eb-98b1-14cd0c255e7f.png)
  ![image](https://user-images.githubusercontent.com/13918850/107799391-03a26c00-6d66-11eb-8b87-9825a9a74344.png)
