### PR TITLE
Impl [Nucio] Function volumes: Bring back Host Path kind

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -35,7 +35,7 @@
     "COLLAPSE_ALL": "Collapse all",
     "CONFIG_MAP": "Config map",
     "CONFIG_MAP_NAME": "Config map name",
-    "CONFIGMAP": "Configmap",
+    "CONFIGMAP": "ConfigMap",
     "CONFIGMAP_KEY": "ConfigMap key",
     "CONFIGMAP_NAME": "ConfigMap name",
     "CONSUMER_GROUP_NAME": "Consumer group name",

--- a/src/nuclio/common/components/collapsing-row/collapsing-row.less
+++ b/src/nuclio/common/components/collapsing-row/collapsing-row.less
@@ -32,6 +32,7 @@
 
     .row-collapse {
         width: 40px;
+        flex: none;
         justify-content: center;
         align-items: flex-start;
         line-height: 51px;
@@ -53,12 +54,15 @@
     }
 
     .item-row {
-        line-height: 48px;
         display: flex;
+        flex-flow: row nowrap;
+        align-items: center;
 
         .item-name {
             font-weight: bold;
             display: flex;
+            flex-flow: row nowrap;
+            align-items: baseline;
             width: 192px;
 
             .text-ellipsis {
@@ -104,6 +108,8 @@
     .single-action {
         visibility: hidden;
         align-items: flex-start;
+        flex: none;
+        padding-right: 4px;
 
         .igz-action-panel {
             transition: unset;

--- a/src/nuclio/common/components/collapsing-row/collapsing-row.tpl.html
+++ b/src/nuclio/common/components/collapsing-row/collapsing-row.tpl.html
@@ -31,6 +31,9 @@
             <div class="item-class" data-ng-if="!$ctrl.isNil($ctrl.item.ui.selectedClass)">
                 {{$ctrl.item.ui.selectedClass.name}}
             </div>
+            <div class="item-class" data-ng-if="!$ctrl.isNil($ctrl.item.volume.hostPath)">
+                {{ 'functions:HOST_PATH' | i18next }}
+            </div>
             <div class="item-class" data-ng-if="!$ctrl.isNil($ctrl.item.volume.flexVolume)">
                 {{ 'functions:V3IO' | i18next }}
             </div>
@@ -76,6 +79,12 @@
                     <span data-ng-if="!$ctrl.isNil($ctrl.item.volumeMount.mountPath)">
                         <span class="field-label">{{ 'functions:MOUNT_PATH' | i18next }}</span>:&nbsp;{{ $ctrl.item.volumeMount.mountPath }};&nbsp;
                     </span>
+                    <span data-ng-if="!$ctrl.isNil($ctrl.item.volume.hostPath)">
+                        <span class="field-label">{{ 'functions:HOST_PATH' | i18next }}</span>:&nbsp;{{ $ctrl.item.volume.hostPath.path }};&nbsp;
+                    </span>
+                    <span data-ng-if="!$ctrl.isNil($ctrl.item.volumeMount.readOnly)">
+                        <span class="field-label">{{ 'common:READ_ONLY' | i18next }}</span>:&nbsp;{{ $ctrl.item.volumeMount.readOnly }};&nbsp;
+                    </span>
                     <span data-ng-if="!$ctrl.isNil($ctrl.item.volume.flexVolume.options.container)">
                         <span class="field-label">{{ 'functions:CONTAINER_NAME' | i18next }}</span>:&nbsp;{{ $ctrl.item.volume.flexVolume.options.container }};&nbsp;
                     </span>
@@ -94,45 +103,6 @@
                     <span data-ng-if="!$ctrl.isNil($ctrl.item.workerAllocatorName)">
                         <span class="field-label">{{ 'functions:WORKER_ALLOCATOR_NAME' | i18next }}</span>:&nbsp;{{ $ctrl.item.workerAllocatorName }};&nbsp;
                     </span>
-                </div>
-
-                <div data-ng-hide="!$ctrl.item.ui.expanded" class="expanded-item-info-block">
-                    <div class="igz-row common-table-cells-container item-info-row"
-                         data-ng-if="!$ctrl.isNil($ctrl.item.url)">
-                        <div class="igz-col-30 common-table-cell field-label">
-                            {{ 'common:URL' | i18next }}:
-                        </div>
-                        <div class="igz-col-70 common-table-cell">
-                            {{ $ctrl.item.url }}
-                        </div>
-                    </div>
-                    <div class="igz-row common-table-cells-container item-info-row"
-                         data-ng-if="!$ctrl.isNil($ctrl.item.maxWorkers)">
-                        <div class="igz-col-30 common-table-cell field-label">
-                            {{ 'functions:MAX_WORKERS' | i18next }}:
-                        </div>
-                        <div class="igz-col-70 common-table-cell">
-                            {{ $ctrl.item.maxWorkers }}
-                        </div>
-                    </div>
-                    <div class="igz-row common-table-cells-container item-info-row"
-                         data-ng-if="!$ctrl.isNil($ctrl.item.secret)">
-                        <div class="igz-col-30 common-table-cell field-label">
-                            {{ 'functions:SECRET' | i18next }}:
-                        </div>
-                        <div class="igz-col-70 common-table-cell">
-                            {{ $ctrl.item.secret }}
-                        </div>
-                    </div>
-                    <div class="igz-row common-table-cells-container item-info-row"
-                         data-ng-repeat="(key, value) in $ctrl.item.attributes">
-                        <div class="igz-col-30 common-table-cell field-label">
-                            {{ key }}:
-                        </div>
-                        <div class="igz-col-70 common-table-cell">
-                            {{ value }}
-                        </div>
-                    </div>
                 </div>
             </div>
         </div>

--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -104,7 +104,8 @@
             }
 
             if (ctrl.isVolumeType()) {
-                var selectedTypeName = !lodash.isNil(ctrl.item.volume.flexVolume)            ? 'v3io'                  :
+                var selectedTypeName = !lodash.isNil(ctrl.item.volume.hostPath)              ? 'hostPath'              :
+                                       !lodash.isNil(ctrl.item.volume.flexVolume)            ? 'v3io'                  :
                                        !lodash.isNil(ctrl.item.volume.secret)                ? 'secret'                :
                                        !lodash.isNil(ctrl.item.volume.configMap)             ? 'configMap'             :
                                        !lodash.isNil(ctrl.item.volume.persistentVolumeClaim) ? 'persistentVolumeClaim' :
@@ -679,7 +680,20 @@
                     }
                 });
 
-                if (item.id === 'v3io') { // see https://github.com/v3io/flex-fuse
+                if (item.id === 'hostPath') {
+                    lodash.defaultsDeep(ctrl.item, {
+                        volume: {
+                            hostPath: {
+                                path: ''
+                            }
+                        },
+                        volumeMount: {
+                            readOnly: false
+                        }
+                    });
+
+                    cleanOtherVolumeClasses('hostPath');
+                } else if (item.id === 'v3io') { // see https://github.com/v3io/flex-fuse
                     lodash.defaultsDeep(ctrl.item, {
                         volume: {
                             flexVolume: {
@@ -923,7 +937,7 @@
         function cleanOtherVolumeClasses(selectedClass) {
             var removeVolume = lodash.unset.bind(null, ctrl.item.volume);
 
-            lodash.chain(['flexVolume', 'secret', 'configMap', 'persistentVolumeClaim'])
+            lodash.chain(['hostPath', 'flexVolume', 'secret', 'configMap', 'persistentVolumeClaim'])
                 .without(selectedClass)
                 .forEach(removeVolume)
                 .value();

--- a/src/nuclio/common/components/edit-item/edit-item.tpl.html
+++ b/src/nuclio/common/components/edit-item/edit-item.tpl.html
@@ -132,6 +132,27 @@
                 </igz-validating-input-field>
             </div>
 
+            <div class="igz-col-45 attribute-field" data-ng-if="!$ctrl.isNil($ctrl.item.volume.hostPath.path)">
+                <div class="field-label">
+                    <span class="asterisk">{{ 'functions:HOST_PATH' | i18next }}</span>
+                </div>
+                <igz-validating-input-field data-field-type="input"
+                                            data-input-name="hostPath"
+                                            data-input-value="$ctrl.item.volume.hostPath.path"
+                                            data-is-focused="false"
+                                            data-form-object="$ctrl.editItemForm"
+                                            data-validation-is-required="true"
+                                            data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_HOST_PATH' | i18next }}"
+                                            data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                            data-update-data-field="volume.hostPath.path">
+                </igz-validating-input-field>
+            </div>
+
+            <div class="igz-col-45 attribute-field" data-ng-if="!$ctrl.isNil($ctrl.item.volumeMount.readOnly)">
+                <input type="checkbox" id="{{$ctrl.getItemName()}}" data-ng-model="$ctrl.item.volumeMount.readOnly">
+                <label for="{{$ctrl.getItemName()}}" class="asterisk">{{ 'common:READ_ONLY' | i18next }}</label>
+            </div>
+
             <div class="igz-col-45 attribute-field" data-ng-if="!$ctrl.isNil($ctrl.item.volume.secret.secretName)">
                 <div class="field-label">
                     <span class="asterisk">{{ 'functions:SECRET_NAME' | i18next }}</span>

--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -786,16 +786,16 @@
                         ]
                     }
                 ],
-                volume: [
+                volume: self.isKubePlatform() ? [
                     {
                         id: 'v3io',
-                        name: 'V3IO',
+                        name: $i18next.t('functions:V3IO', { lng: lng }),
                         tooltip: $i18next.t('functions:TOOLTIP.V3IO', { lng: lng }),
                         moreInfoDescription: $i18next.t('functions:TOOLTIP.V3IO', { lng: lng })
                     },
                     {
                         id: 'secret',
-                        name: 'Secret',
+                        name: $i18next.t('functions:SECRET', { lng: lng }),
                         tooltip: $i18next.t('functions:TOOLTIP.SECRET.HEAD', { lng: lng }) + ' ' +
                             $i18next.t('functions:TOOLTIP.SECRET.REST', { lng: lng }),
                         moreInfoDescription: 'A <a class="link" target="_blank" ' +
@@ -805,7 +805,7 @@
                     },
                     {
                         id: 'configMap',
-                        name: 'ConfigMap',
+                        name: $i18next.t('functions:CONFIGMAP', { lng: lng }),
                         tooltip: $i18next.t('functions:TOOLTIP.CONFIG_MAP.HEAD', { lng: lng }) + ' ' +
                             $i18next.t('functions:TOOLTIP.CONFIG_MAP.REST', { lng: lng }),
                         moreInfoDescription: 'A <a class="link" target="_blank" ' +
@@ -815,7 +815,12 @@
                     },
                     {
                         id: 'persistentVolumeClaim',
-                        name: 'PVC'
+                        name: $i18next.t('functions:PVC', { lng: lng })
+                    }
+                ] : [
+                    {
+                        id: 'hostPath',
+                        name: $i18next.t('functions:HOST_PATH', { lng: lng })
                     }
                 ]
             };

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-volumes/version-configuration-volumes.less
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-volumes/version-configuration-volumes.less
@@ -2,7 +2,8 @@
     .ncl-version-volume {
         .common-table-header {
             border: none;
-            padding-left: 24px;
+            padding-left: 40px;
+            padding-right: 60px;
 
             .common-table-cell {
                 font-size: 14px;
@@ -17,6 +18,7 @@
 
                 .item-name {
                     width: 25%;
+                    padding-left: 0;
                 }
 
                 .item-class {
@@ -32,15 +34,16 @@
         .common-table-body {
             .ncl-collapsing-row .item-row {
                 .item-name {
-                    width: 22%;
+                    padding-left: 0;
+                    width: 25%;
                 }
 
                 .item-class {
-                    width: 18.5%;
+                    width: 20%;
                 }
 
                 .item-info {
-                    width: 58%;
+                    width: 55%;
                 }
             }
 

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-volumes/version-configuration-volumes.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-volumes/version-configuration-volumes.tpl.html
@@ -17,7 +17,7 @@
                     <div class="common-table-cell item-class">
                         {{ 'common:TYPE' | i18next }}
                     </div>
-                    <div class="igz-col-70 common-table-cell">
+                    <div class="common-table-cell item-info">
                         {{ 'functions:MOUNT_PATH_PARAMS' | i18next }}
                     </div>
                 </div>


### PR DESCRIPTION
- Function › Configuration › Volumes: brought back “Host Path” volume kind
  ![image](https://user-images.githubusercontent.com/13918850/108244233-a76d8c80-7157-11eb-8d63-fc7f00af8772.png)
  - Added read-only checkbox to host-path volumes.
    ![image](https://user-images.githubusercontent.com/13918850/108244246-ab99aa00-7157-11eb-966a-8133108e494d.png)
  - For local platform: host path is the only kind available.
    ![image](https://user-images.githubusercontent.com/13918850/108244265-b2c0b800-7157-11eb-8716-8d39d1250805.png)
  - For K8s platform: all kinds besides host path are available.
    ![image](https://user-images.githubusercontent.com/13918850/108244257-afc5c780-7157-11eb-8c5b-538394449270.png)