### PR TITLE
Impl [Nuclio] Click project breadcrumb to go to Project screen

### DIFF
--- a/src/nuclio/common/components/breadcrumbs/breadcrumbs.component.js
+++ b/src/nuclio/common/components/breadcrumbs/breadcrumbs.component.js
@@ -11,7 +11,7 @@
             controller: NclBreadcrumbsController
         });
 
-    function NclBreadcrumbsController($scope, $state, $transitions, lodash) {
+    function NclBreadcrumbsController($scope, $state, $stateParams, $transitions, lodash) {
         var ctrl = this;
 
         ctrl.mainHeaderTitle = {};
@@ -19,7 +19,7 @@
         ctrl.$onInit = onInit;
 
         ctrl.goToProjectsList = goToProjectsList;
-        ctrl.goToFunctionsList = goToFunctionsList;
+        ctrl.goToProjectScreen = goToProjectScreen;
         ctrl.goToFunctionScreen = goToFunctionScreen;
 
         //
@@ -42,19 +42,24 @@
         //
 
         /**
-         * Changes state when the main header title is clicked
+         * Redirects to the projects screen
          */
         function goToProjectsList() {
             $state.go('app.projects');
         }
 
         /**
-         * Changes state when the Project subtitle is clicked
+         * Redirects to the project screen
          */
-        function goToFunctionsList() {
-            $state.go('app.project.functions');
+        function goToProjectScreen() {
+            $state.go('app.project', {
+                projectId: $stateParams.projectId
+            });
         }
 
+        /**
+         * Redirects to the function screen
+         */
         function goToFunctionScreen() {
             $state.go('app.project.function.edit.code');
         }

--- a/src/nuclio/common/components/breadcrumbs/breadcrumbs.tpl.html
+++ b/src/nuclio/common/components/breadcrumbs/breadcrumbs.tpl.html
@@ -8,7 +8,7 @@
 </span>
 
 <span class="main-header-title" data-ng-if="$ctrl.mainHeaderTitle.project.spec.displayName || $ctrl.mainHeaderTitle.project.metadata.name">
-    <span class="main-header-title-text" data-ng-click="$ctrl.goToFunctionsList()">
+    <span class="main-header-title-text" data-ng-click="$ctrl.goToProjectScreen()">
         {{$ctrl.mainHeaderTitle.project.spec.displayName || $ctrl.mainHeaderTitle.project.metadata.name}}
     </span>
 


### PR DESCRIPTION
In Nuclio open-source it will enter the default nested tab, which is currently "Functions".
It allows other consumers to redirect to an external project screen.