### PR TITLE
Impl [Nuclio] Volumes: remove red asterisk from Read Only field

### DIFF
--- a/src/nuclio/common/components/edit-item/edit-item.tpl.html
+++ b/src/nuclio/common/components/edit-item/edit-item.tpl.html
@@ -150,7 +150,7 @@
 
             <div class="igz-col-45 attribute-field" data-ng-if="!$ctrl.isNil($ctrl.item.volumeMount.readOnly)">
                 <input type="checkbox" id="{{$ctrl.getItemName()}}" data-ng-model="$ctrl.item.volumeMount.readOnly">
-                <label for="{{$ctrl.getItemName()}}" class="asterisk">{{ 'common:READ_ONLY' | i18next }}</label>
+                <label for="{{$ctrl.getItemName()}}">{{ 'common:READ_ONLY' | i18next }}</label>
             </div>
 
             <div class="igz-col-45 attribute-field" data-ng-if="!$ctrl.isNil($ctrl.item.volume.secret.secretName)">


### PR DESCRIPTION
- Function › Configuration › Volumes: Removed the red asterisk from the “Read only” checkbox field of the “Host Path” kind
  ![image](https://user-images.githubusercontent.com/13918850/108407812-e7527380-722c-11eb-953b-a7f21a038b5d.png)