### PR TITLE
Impl [Nuclio] Entirely deprecate project disply name

### DIFF
--- a/src/nuclio/common/components/breadcrumbs-dropdown/breadcrumbs-dropdown.component.js
+++ b/src/nuclio/common/components/breadcrumbs-dropdown/breadcrumbs-dropdown.component.js
@@ -126,7 +126,7 @@
             ctrl.itemsList = lodash.map(data, function (item) {
                 return {
                     id: item.metadata.name,
-                    name: lodash.defaultTo(item.spec.displayName, item.metadata.name),
+                    name: item.metadata.name,
                     isNuclioState: true
                 };
             });

--- a/src/nuclio/common/components/breadcrumbs/breadcrumbs.tpl.html
+++ b/src/nuclio/common/components/breadcrumbs/breadcrumbs.tpl.html
@@ -7,13 +7,13 @@
     <span class="igz-icon-right ncl-header-subtitle"></span>
 </span>
 
-<span class="main-header-title" data-ng-if="$ctrl.mainHeaderTitle.project.spec.displayName || $ctrl.mainHeaderTitle.project.metadata.name">
+<span class="main-header-title" data-ng-if="$ctrl.mainHeaderTitle.project.metadata.name">
     <span class="main-header-title-text" data-ng-click="$ctrl.goToProjectScreen()">
-        {{$ctrl.mainHeaderTitle.project.spec.displayName || $ctrl.mainHeaderTitle.project.metadata.name}}
+        {{$ctrl.mainHeaderTitle.project.metadata.name}}
     </span>
 
     <ncl-breadcrumbs-dropdown data-state="$ctrl.mainHeaderTitle.state"
-                              data-title="$ctrl.mainHeaderTitle.project.spec.displayName || $ctrl.mainHeaderTitle.project.metadata.name"
+                              data-title="$ctrl.mainHeaderTitle.project.metadata.name"
                               data-project="$ctrl.mainHeaderTitle.project"
                               data-type="projects"
                               data-get-functions="$ctrl.getFunctions({id: id, enrichApiGateways: enrichApiGateways})"

--- a/src/nuclio/common/screens/create-function/create-function.component.js
+++ b/src/nuclio/common/screens/create-function/create-function.component.js
@@ -80,7 +80,7 @@
 
                             ctrl.selectedProject = {
                                 id: project.metadata.name,
-                                name: lodash.defaultTo(project.spec.displayName, project.metadata.name)
+                                name: project.metadata.name
                             };
                         }
 

--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
@@ -317,7 +317,7 @@
                 .map(function (project) {
                     return {
                         id: project.metadata.name,
-                        name: lodash.defaultTo(project.spec.displayName, project.metadata.name)
+                        name: project.metadata.name
                     };
                 })
                 .sortBy(['name'])

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
@@ -451,7 +451,7 @@
                 .map(function (project) {
                     return {
                         id: project.metadata.name,
-                        name: lodash.defaultTo(project.spec.displayName, project.metadata.name)
+                        name: project.metadata.name
                     };
                 })
                 .sortBy(['name'])

--- a/src/nuclio/common/screens/create-function/function-import/function-import.component.js
+++ b/src/nuclio/common/screens/create-function/function-import/function-import.component.js
@@ -201,7 +201,7 @@
                 .map(function (project) {
                     return {
                         id: project.metadata.name,
-                        name: lodash.defaultTo(project.spec.displayName, project.metadata.name)
+                        name: project.metadata.name
                     };
                 })
                 .sortBy(['name'])

--- a/src/nuclio/common/services/export.service.js
+++ b/src/nuclio/common/services/export.service.js
@@ -56,7 +56,7 @@
                     var projectToExport = {
                         project: {
                             metadata: {
-                                name: lodash.defaultTo(project.spec.displayName, project.metadata.name)
+                                name: project.metadata.name
                             },
                             spec: {
                                 functions: functionsList
@@ -66,7 +66,7 @@
 
                     var blob = prepareBlobObject(projectToExport);
 
-                    downloadExportedFunction(blob, lodash.defaultTo(project.spec.displayName, project.metadata.name));
+                    downloadExportedFunction(blob, project.metadata.name);
                 })
                 .catch(function (error) {
                     var defaultMsg = $i18next.t('functions:ERROR_MSG.EXPORT_PROJECT', {lng: i18next.language});
@@ -96,7 +96,7 @@
                     .then(function (functionsList) {
                         return {
                             metadata: {
-                                name: lodash.defaultTo(project.spec.displayName, project.metadata.name)
+                                name: project.metadata.name
                             },
                             spec: {
                                 functions: lodash.defaultTo(functionsList, [])

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.spec.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.spec.js
@@ -37,7 +37,6 @@ describe('nclFunctionVersionRow component:', function () {
                 'namespace': 'nuclio'
             },
             'spec': {
-                'displayName': 'My project #1',
                 'description': 'Some description'
             }
         };


### PR DESCRIPTION
`spec.displayName` of projects is entirely deprecated.
All references to this property has been deleted.

Relates to PRs https://github.com/iguazio/dashboard-controls/pull/675 https://github.com/nuclio/nuclio/pull/2066