### PR TITLE
Impl [Nuclio] Add "Python 3.9" runtime

### DIFF
--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
@@ -220,6 +220,12 @@
                     visible: true
                 },
                 {
+                    id: 'python:3.9',
+                    name: 'Python 3.9',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
                     id: 'dotnetcore',
                     name: '.NET Core',
                     sourceCode: 'dXNpbmcgU3lzdGVtOw0KdXNpbmcgTnVjbGlvLlNkazsNCg0KcHVibGljIGNsYXNzIG1haW4NCnsNCiAgICBwdWJ' +

--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.spec.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.spec.js
@@ -44,6 +44,12 @@ describe('nclFunctionFromScratch Component:', function () {
                 visible: true
             },
             {
+                id: 'python:3.9',
+                name: 'Python 3.9',
+                sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                visible: true
+            },
+            {
                 id: 'dotnetcore',
                 name: '.NET Core',
                 sourceCode: 'dXNpbmcgU3lzdGVtOw0KdXNpbmcgTnVjbGlvLlNkazsNCg0KcHVibGljIGNsYXNzIG1haW4NCnsNCiAgICBwdWJ' +

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
@@ -385,6 +385,11 @@
                     visible: true
                 },
                 {
+                    id: 'python:3.9',
+                    name: 'Python 3.9',
+                    visible: true
+                },
+                {
                     id: 'dotnetcore',
                     name: '.NET Core',
                     visible: true

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -47,6 +47,7 @@
             'python:3.6': 'Python 3.6',
             'python:3.7': 'Python 3.7',
             'python:3.8': 'Python 3.8',
+            'python:3.9': 'Python 3.9',
             'dotnetcore': '.NET Core',
             'java': 'Java',
             'nodejs': 'NodeJS',

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
@@ -32,6 +32,7 @@
             'python:3.6': 'Python 3.6',
             'python:3.7': 'Python 3.7',
             'python:3.8': 'Python 3.8',
+            'python:3.9': 'Python 3.9',
             'dotnetcore': '.NET Core',
             'java': 'Java',
             'nodejs': 'NodeJS',

--- a/src/nuclio/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/functions/version/version-code/version-code.component.js
@@ -449,6 +449,14 @@
                     visible: true
                 },
                 {
+                    id: 'python:3.9',
+                    ext: 'py',
+                    name: 'Python 3.9',
+                    language: 'python',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
                     id: 'dotnetcore',
                     ext: 'cs',
                     name: '.NET Core',


### PR DESCRIPTION
- Added runtime “Python 3.9”:
  - Create function › From template › Runtime filter
  ![image](https://user-images.githubusercontent.com/13918850/115246128-4863ce00-a12e-11eb-9067-812bbb2ae92d.png)
  - Create function › From scratch › Runtime field
  ![image](https://user-images.githubusercontent.com/13918850/115246150-4dc11880-a12e-11eb-8858-700f5de780a7.png)
  - Function › Code › Runtime field
  ![image](https://user-images.githubusercontent.com/13918850/115246200-574a8080-a12e-11eb-9094-8d78cd662e43.png)
  - Project › Functions (list) › Runtime (column)
  ![image](https://user-images.githubusercontent.com/13918850/115246244-616c7f00-a12e-11eb-8eb8-f4efdf45d064.png)

Relates to PRs https://github.com/nuclio/nuclio/pull/2155

Jira ticket IG-18430