### PR TITLE
Clean [i18n] Rename key message of "Create a new entry"

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -71,6 +71,7 @@
     "CPU_USED": "CPU used",
     "CREATE": "Create",
     "CREATE_FUNCTION": "Create Function",
+    "CREATE_NEW_ENTRY": "Create a new entry",
     "CREATE_NEW_ENVIRONMENT_VARIABLE": "Create a new environment variable",
     "CREATE_TENANT": "Create tenant",
     "CREATE_VIEW": "Create view",

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -53,7 +53,6 @@
     "CREATE_NEW_HEADER": "Create a new header",
     "CREATE_NEW_HOST": "Create a new host",
     "CREATE_NEW_LABEL": "Create a new label",
-    "CREATE_NEW_NODE_SELECTOR": "Create a new entry",
     "CREATE_NEW_RUNTIME_ATTRIBUTE": "Create a new runtime attribute",
     "CREATE_NEW_SUBSCRIPTION": "Create a new subscription",
     "CREATE_NEW_TRIGGER": "Create a new trigger",

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
@@ -258,7 +258,7 @@
                 </div>
                 <div class="igz-create-button" data-ng-click="$ctrl.addNewNodeSelector($event)">
                     <span class="igz-icon-add-round"></span>
-                    {{ 'functions:CREATE_NEW_NODE_SELECTOR' | i18next }}
+                    {{ 'common:CREATE_NEW_ENTRY' | i18next }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- **i18n**: Renamed message key `CREATE_NEW_NODE_SELECTOR` to `CREATE_NEW_ENTRY` to accurately describe its value (“Create a new entry”) and move it to namespace `common`.