### PR TITLE
Impl [Nuclio] Triggers: add Tech Preview note for a few classes

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -468,6 +468,7 @@
     "TARGET_CPU": "Target CPU",
     "TARGET_CPU_DESCRIPTION": "Exceeding this threshold will increase the number of replicas",
     "TASKS": "Tasks",
+    "TECH_PREVIEW": "Tech Preview",
     "TENANT": "Tenant",
     "TENANT_NAME": "Tenant name",
     "TENANTS": "Tenants",

--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -207,6 +207,7 @@
                     {
                         id: 'rabbit-mq',
                         name: 'RabbitMQ',
+                        description: $i18next.t('common:TECH_PREVIEW', { lng: lng }),
                         tooltip: 'RabbitMQ',
                         tooltipOriginal: 'RabbitMQ',
                         tooltipPlacement: 'right',
@@ -256,6 +257,7 @@
                     {
                         id: 'nats',
                         name: 'NATS',
+                        description: $i18next.t('common:TECH_PREVIEW', { lng: lng }),
                         tooltip: 'NATS',
                         tooltipOriginal: 'NATS',
                         tooltipPlacement: 'right',
@@ -365,6 +367,7 @@
                     {
                         id: 'eventhub',
                         name: 'Azure Event Hubs',
+                        description: $i18next.t('common:TECH_PREVIEW', { lng: lng }),
                         tooltip: 'Azure Event Hubs',
                         tooltipOriginal: 'Azure Event Hubs',
                         tooltipPlacement: 'right',
@@ -675,6 +678,7 @@
                     {
                         id: 'kinesis',
                         name: 'Kinesis',
+                        description: $i18next.t('common:TECH_PREVIEW', { lng: lng }),
                         tooltip: 'Kinesis',
                         tooltipOriginal: 'Kinesis',
                         tooltipPlacement: 'right',
@@ -739,6 +743,7 @@
                     {
                         id: 'mqtt',
                         name: 'MQTT',
+                        description: $i18next.t('common:TECH_PREVIEW', { lng: lng }),
                         tooltip: 'MQTT',
                         tooltipOriginal: 'MQTT',
                         tooltipPlacement: 'right',


### PR DESCRIPTION
- “Function” screen › “Triggers” tab › “Class” field: added a “Tech preview” note for the following options: 
  - Kinesis
  - RabittMQ
  - NATS
  - Event Hub
  - MQTT
  ![image](https://user-images.githubusercontent.com/13918850/122401665-79714b00-cf85-11eb-95a6-7e3ca40c9803.png)
  ![image](https://user-images.githubusercontent.com/13918850/122401689-7d9d6880-cf85-11eb-93c2-f3542f0619ea.png)

Jira ticket IG-18747