### PR TITLE
Fix [Nuclio] Functions: table overflows viewport

### DIFF
--- a/src/igz_controls/services/table-size.service.js
+++ b/src/igz_controls/services/table-size.service.js
@@ -155,36 +155,32 @@
         };
         var functionsTableColSizes = {
             headerName: {
-                default: '10',
+                default: '12-5',
                 demo: '10'
             },
             rowName: {
-                default: '10',
+                default: '12-5',
                 demo: '10'
             },
             status: {
-                default: '7-5',
-                demo: '7-5'
+                default: '12-5',
+                demo: '10'
             },
             replicas: {
                 default: '5',
                 demo: '5'
             },
             owner: {
-                default: '7-5',
-                demo: '7-5'
+                default: '10',
+                demo: '10'
             },
             runtime: {
-                default: '7-5',
-                demo: '7-5'
-            },
-            invocationUrl: {
-                default: '12-5',
+                default: '10',
                 demo: '10'
             },
             invocationPerSec: {
                 default: '10',
-                demo: '7-5'
+                demo: '10'
             },
             cpuCores: {
                 default: '15',

--- a/src/nuclio/functions/functions.less
+++ b/src/nuclio/functions/functions.less
@@ -12,8 +12,6 @@ ncl-functions {
 
   .igz-info-page-content-wrapper {
     .igz-info-page-content {
-      min-width: 1380px;
-
       .table-actions {
         display: flex;
         align-items: center;


### PR DESCRIPTION
- Functions: table was overflowing the viewport on the right edge
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/122562791-20b8b580-d04c-11eb-9849-a4a400361375.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/122562803-231b0f80-d04c-11eb-9e87-46907f1ac40c.png)

Bug originated in PR https://github.com/iguazio/dashboard-controls/pull/1231
Clean up after PR https://github.com/iguazio/dashboard-controls/pull/1233 (removed “Invocation URL” column but didn't delete its width details)