### PR TITLE
Impl [Nuclio] Test pane: add selection of invocation URL

### DIFF
--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.less
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.less
@@ -279,20 +279,7 @@
             height: 38px;
             padding: 0 23px;
 
-            .path {
-                display: flex;
-                align-items: center;
-                font-weight: bold;
-                margin-left: 22px;
-
-                .invocation-url {
-                    color: @cool-grey;
-                }
-            }
-
             .default-dropdown {
-                width: 97px;
-
                 .default-dropdown-field:not(:hover) {
                     border-color: transparent;
                 }
@@ -302,12 +289,18 @@
                 }
             }
 
+            .method-select {
+                max-width: 100px;
+            }
+
+            .invocation-urls-select {
+                flex: auto;
+            }
+
             .validating-input-field {
                 font-size: 14px;
-                margin-top: -2px;
 
                 .input-field {
-                    padding: 0 1px;
                     background-color: @pale-grey-three;
                 }
             }

--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.tpl.html
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.tpl.html
@@ -101,25 +101,26 @@
                              data-ng-scrollbars
                              data-ng-scrollbars-config="$ctrl.scrollConfig">
                             <div class="request-method">
-                                <igz-default-dropdown data-values-array="$ctrl.requestMethods"
+                                <igz-default-dropdown class="method-select"
+                                                      data-values-array="$ctrl.requestMethods"
                                                       data-select-property-only="name"
                                                       data-selected-item="$ctrl.selectedEvent.spec.attributes.method"
                                                       data-item-select-callback="$ctrl.onChangeRequestMethod(item)"
                                                       data-enable-overlap="true">
                                 </igz-default-dropdown>
-                                <div class="path">
-                                    <span class="invocation-url" data-ng-if="$ctrl.version.ui.invocationUrl.valid">
-                                        {{$ctrl.version.ui.invocationUrl.text}}/
-                                    </span>
-                                    <span data-ng-if="!$ctrl.version.ui.invocationUrl.valid">
-                                        {{ 'common:PATH' | i18next }}:
-                                    </span>
-                                    <igz-validating-input-field data-field-type="input"
-                                                                data-input-value="$ctrl.selectedEvent.spec.attributes.path"
-                                                                data-update-data-field="spec.attributes.path"
-                                                                data-update-data-callback="$ctrl.inputValueCallback(newData, field)">
-                                    </igz-validating-input-field>
-                                </div>
+                                <igz-default-dropdown class="invocation-urls-select"
+                                                      data-values-array="$ctrl.invocationUrls.options"
+                                                      data-select-property-only="name"
+                                                      data-selected-item="$ctrl.invocationUrls.selected"
+                                                      data-item-select-callback="$ctrl.onChangeInvocationUrl(item)"
+                                                      data-enable-overlap="true">
+                                </igz-default-dropdown>
+                                <igz-validating-input-field data-field-type="input"
+                                                            data-input-value="$ctrl.selectedEvent.spec.attributes.path"
+                                                            data-update-data-field="spec.attributes.path"
+                                                            data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                            data-placeholder-text="{{'common:PATH' | i18next}}">
+                                </igz-validating-input-field>
                             </div>
                             <div class="request-body">
                                 <ncl-test-events-navigation-tabs data-active-tab="$ctrl.selectedRequestTab"

--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -200,7 +200,6 @@
 
             setImageNamePrefixTemplate();
             setIngressHost();
-            setInvocationUrl();
         }
 
         //
@@ -390,7 +389,6 @@
 
                     setImageNamePrefixTemplate();
                     setIngressHost();
-                    setInvocationUrl();
                 })
                 .catch(function (error) {
                     var defaultMsg = $i18next.t('functions:ERROR_MSG.GET_FUNCTION', { lng: lng });
@@ -518,7 +516,6 @@
 
                             setImageNamePrefixTemplate();
                             setIngressHost();
-                            setInvocationUrl();
 
                             ctrl.isFunctionDeployed = true;
                         }
@@ -565,13 +562,6 @@
                 defaultImageName: defaultImageName,
                 imageNamePrefix: imageNamePrefix
             });
-        }
-
-        /**
-         * Sets the invocation URL of the function
-         */
-        function setInvocationUrl() {
-            ctrl.version.ui.invocationUrl = VersionHelperService.getInvocationUrl(ctrl.version);
         }
 
         /**


### PR DESCRIPTION
- “Function” screen › “Code” tab › “Test” pane: Added a select field of all internal and external invocation URLs, and replaced use of `x-nuclio-invoke-via` HTTP request header with `x-nuclio-invoke-url` that uses the selected URL.
  ![image](https://user-images.githubusercontent.com/13918850/122563610-10550a80-d04d-11eb-9fcb-695ad452f061.png)
  ![image](https://user-images.githubusercontent.com/13918850/122563617-11863780-d04d-11eb-9a15-226d889e0216.png)

Relates to PR https://github.com/iguazio/dashboard-controls/pull/1233
Reverts parts that were implemented in PR  https://github.com/iguazio/dashboard-controls/pull/1102
Uses backend API from PR https://github.com/iguazio/zebo/pull/5206

Jira tickets IG-18594 IG-18595