### PR TITLE
Impl [Nuclio] Code: enforce only one of Branch, Tag, Reference

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -231,6 +231,7 @@
         "ENTER_SECRET_ACCESS_KEY": "Enter secret access key...",
         "ENTER_SECRET_NAME": "Enter secret name...",
         "ENTER_SESSION_TOKEN": "Enter session token...",
+        "ENTER_TAG": "Enter tag...",
         "ENTER_TOKEN": "Enter token...",
         "ENTER_VALUE": "Enter value...",
         "EVENT_NAME": "Event name...",
@@ -315,6 +316,7 @@
         "DEPLOY_IN_PROGRESS": "Deploy is already in-progress",
         "DISABLE_CACHE": "Build the function's Docker image from scratch without reusing any previously built Docker image layers",
         "DISABLED_FUNCTION": "Only running and scaled-to-zero functions can be tested",
+        "GIT_BRANCH_TAG_REFERENCE_DISABLED": "Exactly one of Branch, Tag, and Reference fields must be filled. When one is filled, the others are disabled.",
         "GITHUB": {
             "BRANCH": "The GitHub repository branch from which to download the function code",
             "TOKEN": "A GitHub access token for download authentication",

--- a/src/nuclio/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/functions/version/version-code/version-code.tpl.html
@@ -191,19 +191,29 @@
                     <div data-ng-if="$ctrl.selectedEntryType.id === 'github' || $ctrl.selectedEntryType.id === 'git'"
                          class="ncl-code-entry-url">
                         <div class="field-label">
-                            <span class="asterisk">{{ 'functions:BRANCH' | i18next }}</span>
+                            <span data-ng-class="{ asterisk: $ctrl.selectedEntryType.id === 'github' }">{{ 'functions:BRANCH' | i18next }}</span>
                             <igz-more-info data-description="{{ 'functions:TOOLTIP.GITHUB.BRANCH' | i18next }}"></igz-more-info>
                         </div>
-                        <igz-validating-input-field data-field-type="input"
-                                                    data-input-name="githubBranch"
-                                                    data-input-value="$ctrl.version.spec.build.codeEntryAttributes.branch"
-                                                    data-is-focused="false"
-                                                    data-form-object="$ctrl.versionCodeForm"
-                                                    data-validation-is-required="true"
-                                                    data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: master"
-                                                    data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.branch">
-                        </igz-validating-input-field>
+                        <div data-uib-tooltip="{{
+                            $ctrl.version.spec.build.codeEntryAttributes.tag ||
+                            $ctrl.version.spec.build.codeEntryAttributes.reference
+                                ? ('functions:TOOLTIP.GIT_BRANCH_TAG_REFERENCE_DISABLED' | i18next)
+                                : ''}}"
+                             data-tooltip-placement="top"
+                             data-tooltip-popup-delay="200"
+                             data-tooltip-append-to-body="true">
+                            <igz-validating-input-field data-field-type="input"
+                                                        data-input-name="githubBranch"
+                                                        data-input-value="$ctrl.version.spec.build.codeEntryAttributes.branch"
+                                                        data-is-focused="false"
+                                                        data-form-object="$ctrl.versionCodeForm"
+                                                        data-validation-is-required="$ctrl.selectedEntryType.id === 'github'"
+                                                        data-placeholder-text="{{ 'common:FOR_EXAMPLE' | i18next }}: master"
+                                                        data-is-disabled="$ctrl.version.spec.build.codeEntryAttributes.tag || $ctrl.version.spec.build.codeEntryAttributes.reference"
+                                                        data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                        data-update-data-field="spec.build.codeEntryAttributes.branch">
+                            </igz-validating-input-field>
+                        </div>
                     </div>
 
                     <div data-ng-if="$ctrl.selectedEntryType.id === 'github'"
@@ -228,15 +238,26 @@
                         <div class="field-label">
                             <span>{{ 'common:TAG' | i18next }}</span>
                         </div>
-                        <igz-validating-input-field data-field-type="input"
-                                                    data-input-name="git"
-                                                    data-input-value="$ctrl.version.spec.build.codeEntryAttributes.tag"
-                                                    data-is-focused="false"
-                                                    data-form-object="$ctrl.versionCodeForm"
-                                                    data-validation-is-required="false"
-                                                    data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.tag">
-                        </igz-validating-input-field>
+                        <div data-uib-tooltip="{{
+                            $ctrl.version.spec.build.codeEntryAttributes.branch ||
+                            $ctrl.version.spec.build.codeEntryAttributes.reference
+                                ? ('functions:TOOLTIP.GIT_BRANCH_TAG_REFERENCE_DISABLED' | i18next)
+                                : ''}}"
+                             data-tooltip-placement="top"
+                             data-tooltip-popup-delay="200"
+                             data-tooltip-append-to-body="true">
+                            <igz-validating-input-field data-field-type="input"
+                                                        data-input-name="git"
+                                                        data-input-value="$ctrl.version.spec.build.codeEntryAttributes.tag"
+                                                        data-is-focused="false"
+                                                        data-form-object="$ctrl.versionCodeForm"
+                                                        data-validation-is-required="false"
+                                                        data-is-disabled="$ctrl.version.spec.build.codeEntryAttributes.branch || $ctrl.version.spec.build.codeEntryAttributes.reference"
+                                                        data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_TAG' | i18next }}"
+                                                        data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                        data-update-data-field="spec.build.codeEntryAttributes.tag">
+                            </igz-validating-input-field>
+                        </div>
                     </div>
 
                     <div data-ng-if="$ctrl.selectedEntryType.id === 'git'"
@@ -244,16 +265,26 @@
                         <div class="field-label">
                             <span>{{ 'functions:REFERENCE' | i18next }}</span>
                         </div>
-                        <igz-validating-input-field data-field-type="input"
-                                                    data-input-name="gitReference"
-                                                    data-input-value="$ctrl.version.spec.build.codeEntryAttributes.reference"
-                                                    data-is-focused="false"
-                                                    data-form-object="$ctrl.versionCodeForm"
-                                                    data-validation-is-required="false"
-                                                    data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_REFERENCE' | i18next }}"
-                                                    data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
-                                                    data-update-data-field="spec.build.codeEntryAttributes.reference">
-                        </igz-validating-input-field>
+                        <div data-uib-tooltip="{{
+                            $ctrl.version.spec.build.codeEntryAttributes.branch ||
+                            $ctrl.version.spec.build.codeEntryAttributes.tag
+                                ? ('functions:TOOLTIP.GIT_BRANCH_TAG_REFERENCE_DISABLED' | i18next)
+                                : ''}}"
+                             data-tooltip-placement="top"
+                             data-tooltip-popup-delay="200"
+                             data-tooltip-append-to-body="true">
+                            <igz-validating-input-field data-field-type="input"
+                                                        data-input-name="gitReference"
+                                                        data-input-value="$ctrl.version.spec.build.codeEntryAttributes.reference"
+                                                        data-is-focused="false"
+                                                        data-form-object="$ctrl.versionCodeForm"
+                                                        data-validation-is-required="false"
+                                                        data-is-disabled="$ctrl.version.spec.build.codeEntryAttributes.branch || $ctrl.version.spec.build.codeEntryAttributes.tag"
+                                                        data-placeholder-text="{{ 'functions:PLACEHOLDER.ENTER_REFERENCE' | i18next }}"
+                                                        data-update-data-callback="$ctrl.inputValueCallback(newData, field)"
+                                                        data-update-data-field="spec.build.codeEntryAttributes.reference">
+                            </igz-validating-input-field>
+                        </div>
                     </div>
 
                     <div data-ng-if="$ctrl.selectedEntryType.id === 'git'"


### PR DESCRIPTION
- “Function” screen › “Code” tab › “Git” code-entry type: Enforce filling only one of “Branch”, ”Tag” or “Reference” fields. When one is filled the others are disabled (and on hovering them when disabled a tooltip shows to explain this)
  ![image](https://user-images.githubusercontent.com/13918850/129399851-0a4d0951-1675-415c-866b-23b3df701304.png)

Jira ticket IG-18752