### PR TITLE
[Nuclio] Populate default node selector entries

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -270,7 +270,7 @@
     "RESPONSE": "Response",
     "RESPONSE_HEADERS": "Response headers",
     "RESPONSE_IMAGE": "Response image",
-    "REVERT_NODE_SELECTORS_TO_DEFAULTS": "Are you sure you want revert the node selectors to its defaults?",
+    "REVERT_NODE_SELECTORS_TO_DEFAULTS_CONFIRM": "Are you sure you want revert the node selectors to its defaults?",
     "REVERT_TO_DEFAULTS": "Revert to defaults",
     "RUNTIME": "Runtime",
     "RUNTIME_ATTRIBUTES": "Runtime Attributes",
@@ -381,6 +381,6 @@
     "WORKER_AVAILABILITY_TIMEOUT": "Worker availability timeout",
     "WORKER_AVAILABILITY_TIMEOUT_MILLISECONDS": "Worker availability timeout (Milliseconds)",
     "WORKER_AVAILABILITY_TIMEOUT_MILLISECONDS_DESCRIPTION": "The number of milliseconds to wait for a worker if one is not available.\n(default: {{default}})",
-    "YES_REVERT": "YES, REVERT",
+    "YES_REVERT_CONFIRM": "Yes, revert",
     "YOU_CAN_DOWNLOAD_RESPONSE_BODY": "You can download response body"
 }

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -270,6 +270,7 @@
     "RESPONSE": "Response",
     "RESPONSE_HEADERS": "Response headers",
     "RESPONSE_IMAGE": "Response image",
+    "REVERT_TO_DEFAULTS": "Revert to defaults",
     "RUNTIME": "Runtime",
     "RUNTIME_ATTRIBUTES": "Runtime Attributes",
     "SASL_PASSWORD": "SASL password",

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -270,6 +270,7 @@
     "RESPONSE": "Response",
     "RESPONSE_HEADERS": "Response headers",
     "RESPONSE_IMAGE": "Response image",
+    "REVERT_NODE_SELECTORS_TO_DEFAULTS": "Are you sure you want revert the node selectors to its defaults?",
     "REVERT_TO_DEFAULTS": "Revert to defaults",
     "RUNTIME": "Runtime",
     "RUNTIME_ATTRIBUTES": "Runtime Attributes",
@@ -380,5 +381,6 @@
     "WORKER_AVAILABILITY_TIMEOUT": "Worker availability timeout",
     "WORKER_AVAILABILITY_TIMEOUT_MILLISECONDS": "Worker availability timeout (Milliseconds)",
     "WORKER_AVAILABILITY_TIMEOUT_MILLISECONDS_DESCRIPTION": "The number of milliseconds to wait for a worker if one is not available.\n(default: {{default}})",
+    "YES_REVERT": "YES, REVERT",
     "YOU_CAN_DOWNLOAD_RESPONSE_BODY": "You can download response body"
 }

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
@@ -13,7 +13,7 @@
         });
 
     function NclVersionConfigurationResourcesController($i18next, $rootScope, $scope, $stateParams, $timeout, i18next,
-                                                        lodash, ConfigService, FormValidationService) {
+                                                        lodash, ConfigService, DialogsService, FormValidationService) {
         var ctrl = this;
         var lng = i18next.language;
 
@@ -99,12 +99,12 @@
         ctrl.cpuInputCallback = cpuInputCallback;
         ctrl.gpuInputCallback = gpuInputCallback;
         ctrl.handleNodeSelectorsAction = handleNodeSelectorsAction;
+        ctrl.handleRevertToDefaultsClick = handleRevertToDefaultsClick;
         ctrl.isInactivityWindowShown = isInactivityWindowShown;
         ctrl.memoryDropdownCallback = memoryDropdownCallback;
         ctrl.memoryInputCallback = memoryInputCallback;
         ctrl.onChangeNodeSelectorsData = onChangeNodeSelectorsData;
         ctrl.replicasInputCallback = replicasInputCallback;
-        ctrl.setNodeSelectorsDefaultValue = setNodeSelectorsDefaultValue;
         ctrl.sliderInputCallback = sliderInputCallback;
 
         //
@@ -269,6 +269,16 @@
             }
         }
 
+        /**
+         * Handle Revert do defaults click
+         */
+        function handleRevertToDefaultsClick() {
+            DialogsService.confirm($i18next.t('functions:REVERT_NODE_SELECTORS_TO_DEFAULTS', {lng: lng}),
+                                   $i18next.t('functions:YES_REVERT', {lng: lng}),
+                                   $i18next.t('common:CANCEL', {lng: lng})).then(function () {
+                setNodeSelectorsDefaultValue();
+            });
+        }
 
         /**
          * Checks whether the inactivity window can be shown
@@ -371,28 +381,6 @@
             }
 
             ctrl.onChangeCallback();
-        }
-
-        /**
-         * Set Node selectors default value
-         */
-        function setNodeSelectorsDefaultValue() {
-            ctrl.nodeSelectors = lodash.chain(ConfigService)
-                .get('nuclio.defaultFunctionConfig.attributes.spec.nodeSelector', [])
-                .map(function (value, key) {
-                    return {
-                        name: key,
-                        value: value,
-                        ui: {
-                            editModeActive: false,
-                            isFormValid: key.length > 0 && value.length > 0,
-                            name: 'nodeSelector'
-                        }
-                    };
-                })
-                .value();
-
-            ctrl.revertToDefaultsBtnIsHidden = true;
         }
 
         /**
@@ -650,6 +638,26 @@
          */
         function isRequestsInput(field) {
             return lodash.includes(field.toLowerCase(), 'request');
+        }
+
+        /**
+         * Set Node selectors default value
+         */
+        function setNodeSelectorsDefaultValue() {
+            ctrl.nodeSelectors = lodash.chain(ConfigService)
+                .get('nuclio.defaultFunctionConfig.attributes.spec.nodeSelector', [])
+                .map(function (value, key) {
+                    return {
+                        name: key,
+                        value: value,
+                        ui: {
+                            editModeActive: false,
+                            isFormValid: key.length > 0 && value.length > 0,
+                            name: 'nodeSelector'
+                        }
+                    };
+                })
+                .value();
         }
 
         /**

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
@@ -242,7 +242,14 @@
         </div>
     </form>
     <form name="$ctrl.nodeSelectorsForm" novalidate>
-        <div class="title">{{ 'functions:NODE_SELECTORS' | i18next }}</div>
+        <div class="igz-row-flex">
+            <div class="title">{{ 'functions:NODE_SELECTORS' | i18next }}</div>
+            <a class="link"
+               data-ng-click="$ctrl.setNodeSelectorsDefaultValue()"
+               data-ng-hide="$ctrl.revertToDefaultsBtnIsHidden">
+                {{ 'functions:REVERT_TO_DEFAULTS' | i18next }}
+            </a>
+        </div>
         <div class="row">
             <div class="igz-row form-row">
                 <div class="table-body" data-ng-repeat="nodeSelector in $ctrl.nodeSelectors">

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
@@ -245,7 +245,7 @@
         <div class="igz-row-flex">
             <div class="title">{{ 'functions:NODE_SELECTORS' | i18next }}</div>
             <a class="link"
-               data-ng-click="$ctrl.setNodeSelectorsDefaultValue()"
+               data-ng-click="$ctrl.handleRevertToDefaultsClick()"
                data-ng-hide="$ctrl.revertToDefaultsBtnIsHidden">
                 {{ 'functions:REVERT_TO_DEFAULTS' | i18next }}
             </a>


### PR DESCRIPTION
https://trello.com/c/HyTMRmXX/948-nuclio-populate-default-node-selector-entries

- “Function” screen › “Configuration” tab › “Node Selector” section:
  - Pre-populates with default node-selector entries coming from `GET /api/frontend_spec` endpoint.
  - Added “Revert to defaults” action to restore these defaults if they were changed.
  ![image](https://user-images.githubusercontent.com/13918850/130333590-fe42293f-6389-4c85-a5a8-09824c8f48d2.png)
  ![image](https://user-images.githubusercontent.com/13918850/130333593-443a5da3-2bf2-4526-af98-bb42cbe80942.png)

Jira ticket IG-19075