### PR TITLE
Fix [Nuclio] Triggers: Cron trigger schedule unexpectedly changed

### DIFF
--- a/src/nuclio/functions/version/version-triggers/version-triggers.component.js
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.component.js
@@ -409,7 +409,8 @@
          */
         function updateTriggerList() {
             ctrl.triggers = lodash.map(ctrl.version.spec.triggers, function (trigger) {
-                var triggersItem = lodash.assign(lodash.cloneDeep(trigger), createTriggerItem(trigger));
+                var clone = lodash.cloneDeep(trigger);
+                var triggersItem = lodash.assign(clone, createTriggerItem(clone));
 
                 lodash.defaults(triggersItem, {
                     attributes: {}


### PR DESCRIPTION
Backports PR https://github.com/iguazio/dashboard-controls/pull/1255 from branch **development** into branch **v0.31.1-cron**.

- “Function“ screen › “Triggers” tab: [bugfix] For triggers of type Cron, the “Schedule” field (bound to `attributes.schedule`) was unexpectedly changed from 6 fields (for example `0 0 5 * * *`) to 5 fields (for example `0 5 * * *`) — which totally changed the scheduling of the trigger.

Jira ticket IG-18937