### PR TITLE
[Validating Input Field] Width flicker on value change

### DIFF
--- a/src/igz_controls/components/validating-input-field/validating-input-field.less
+++ b/src/igz_controls/components/validating-input-field/validating-input-field.less
@@ -44,13 +44,14 @@
 
     .validation-icon,
     .validation-rule-icon {
+        width: 14px;
+        font-size: 11px;
+
         &.igz-icon-verify-ok {
-            font-size: 11px;
             color: @validation-icon-ok-color;
         }
 
         &.ncl-icon-close {
-            font-size: 10px;
             color: @validation-icon-close-color;
         }
     }


### PR DESCRIPTION
https://trello.com/c/OFFr9uw0/959-validating-input-field-width-flicker-on-value-change

- `igzValidatingInputField`: The checmark and cross icons weren't occupying the same room, so changing the value could cause the width of the menu to change
  Before:
  ![validating-input-field-width-bug](https://user-images.githubusercontent.com/13918850/131860805-f0bc2945-3a05-4f12-bdbe-b476024c4140.gif)
  After:
  ![validating-input-field-width-fix](https://user-images.githubusercontent.com/13918850/131860828-3d7733a8-5c53-43a8-8fd8-531a3374f4a9.gif)
