### PR TITLE
[Nuclio] Node Selector: empty after new function deploy

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
@@ -144,7 +144,7 @@
                 ctrl.maxReplicas = lodash.get(ctrl.version, 'spec.maxReplicas');
 
                 initScaleToZeroData();
-                initNodeSelectors();
+                initNodeSelectors(changes.version.isFirstChange());
 
                 $timeout(function () {
                     setFormValidity();
@@ -504,7 +504,7 @@
         /**
          * Initializes data for Node selectors section
          */
-        function initNodeSelectors() {
+        function initNodeSelectors(isFirstInit) {
             ctrl.nodeSelectors = lodash.chain(ctrl.version)
                 .get('spec.nodeSelector', {})
                 .map(function (value, key) {
@@ -520,7 +520,7 @@
                 })
                 .value();
 
-            if ($stateParams.isNewFunction) {
+            if ($stateParams.isNewFunction && isFirstInit) {
                 setNodeSelectorsDefaultValue();
             } else {
                 checkNodeSelectorsIdentity();


### PR DESCRIPTION
https://trello.com/c/7dXTDfkL/987-nuclio-node-selector-empty-after-new-function-deploy

- Function › Configuration › Node Selector: When deploying a new function with node-selector entries, on deploy completion the node-selector entries cleared from the view. Refreshing the web-browser tab made them re-appear.

Jira ticket IG-19302