### PR TITLE
Impl [Nuclio] Code: Add tooltips to Git code-entry type

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -74,6 +74,7 @@
     "DELETE_PROJECTS_CONFIRM": "Delete selected projects?",
     "DELETE_VERSION": "Delete version",
     "DELETE_VERSIONS_CONFIRM": "Are you sure you want to delete selected versions?",
+    "DELETED_FUNCTION_WHILE_DEPLOYING_MSG": "The function was deleted by someone else before it completed its deployment. You can deploy it again to recreate it, or go to the functions list.",
     "DEPENDENCIES": "Dependencies",
     "DEPLOY": "Deploy",
     "DEPLOYING": "Deploying...",
@@ -134,6 +135,7 @@
     "FUNCTIONS_NOT_FOUND": "There are currently no functions, you can create a function by clicking the ‘New Function’ button",
     "GET_STARTED_WITH_YOUR_PROJECT": "Get started with your project.",
     "GO_TO_EXISTING_FUNCTION": "Go to existing function",
+    "GO_TO_FUNCTIONS": "Go to functions",
     "HANDLER": "Handler",
     "HEADERS": "Headers",
     "HISTORY": "History",
@@ -315,7 +317,12 @@
         "DEPLOY_IN_PROGRESS": "Deploy is already in-progress",
         "DISABLE_CACHE": "Build the function's Docker image from scratch without reusing any previously built Docker image layers",
         "DISABLED_FUNCTION": "Only running and scaled-to-zero functions can be tested",
-        "GIT_BRANCH_TAG_REFERENCE_DISABLED": "Exactly one of Branch, Tag, and Reference fields must be filled. When one is filled, the others are disabled.",
+        "GIT": {
+            "BRANCH": "The Git repository branch from which to download the function code",
+            "BRANCH_TAG_REFERENCE_DISABLED": "Exactly one of Branch, Tag, and Reference fields must be filled. When one is filled, the others are disabled.",
+            "URL": "The URL of the Git repository that contains the function code",
+            "USERNAME": "Not required if you enter a PAT (Personal Access Token) in the Password field"
+        },
         "GITHUB": {
             "BRANCH": "The GitHub repository branch from which to download the function code",
             "TOKEN": "A GitHub access token for download authentication",

--- a/src/nuclio/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/functions/version/version-code/version-code.component.js
@@ -98,6 +98,8 @@
                         }
                     }
                 },
+                tooltip: 'Download the function code from a Git repository',
+                tooltipPlacement: 'right'
             },
             {
                 id: 'github',

--- a/src/nuclio/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/functions/version/version-code/version-code.tpl.html
@@ -174,7 +174,7 @@
                          class="ncl-code-entry-url">
                         <div class="field-label">
                             <span class="asterisk">{{ 'common:URL' | i18next }}</span>
-                            <igz-more-info data-description="{{ 'functions:TOOLTIP.GITHUB.URL' | i18next }}"></igz-more-info>
+                            <igz-more-info data-description="{{ $ctrl.selectedEntryType.id === 'git' ? 'functions:TOOLTIP.GIT.URL' : 'functions:TOOLTIP.GITHUB.URL' | i18next }}"></igz-more-info>
                         </div>
                         <igz-validating-input-field data-field-type="input"
                                                     data-input-name="githubUrl"
@@ -192,12 +192,12 @@
                          class="ncl-code-entry-url">
                         <div class="field-label">
                             <span data-ng-class="{ asterisk: $ctrl.selectedEntryType.id === 'github' }">{{ 'functions:BRANCH' | i18next }}</span>
-                            <igz-more-info data-description="{{ 'functions:TOOLTIP.GITHUB.BRANCH' | i18next }}"></igz-more-info>
+                            <igz-more-info data-description="{{ $ctrl.selectedEntryType.id === 'git' ? 'functions:TOOLTIP.GIT.BRANCH' : 'functions:TOOLTIP.GITHUB.BRANCH' | i18next }}"></igz-more-info>
                         </div>
                         <div data-uib-tooltip="{{
                             $ctrl.version.spec.build.codeEntryAttributes.tag ||
                             $ctrl.version.spec.build.codeEntryAttributes.reference
-                                ? ('functions:TOOLTIP.GIT_BRANCH_TAG_REFERENCE_DISABLED' | i18next)
+                                ? ('functions:TOOLTIP.GIT.BRANCH_TAG_REFERENCE_DISABLED' | i18next)
                                 : ''}}"
                              data-tooltip-placement="top"
                              data-tooltip-popup-delay="200"
@@ -241,7 +241,7 @@
                         <div data-uib-tooltip="{{
                             $ctrl.version.spec.build.codeEntryAttributes.branch ||
                             $ctrl.version.spec.build.codeEntryAttributes.reference
-                                ? ('functions:TOOLTIP.GIT_BRANCH_TAG_REFERENCE_DISABLED' | i18next)
+                                ? ('functions:TOOLTIP.GIT.BRANCH_TAG_REFERENCE_DISABLED' | i18next)
                                 : ''}}"
                              data-tooltip-placement="top"
                              data-tooltip-popup-delay="200"
@@ -268,7 +268,7 @@
                         <div data-uib-tooltip="{{
                             $ctrl.version.spec.build.codeEntryAttributes.branch ||
                             $ctrl.version.spec.build.codeEntryAttributes.tag
-                                ? ('functions:TOOLTIP.GIT_BRANCH_TAG_REFERENCE_DISABLED' | i18next)
+                                ? ('functions:TOOLTIP.GIT.BRANCH_TAG_REFERENCE_DISABLED' | i18next)
                                 : ''}}"
                              data-tooltip-placement="top"
                              data-tooltip-popup-delay="200"
@@ -291,6 +291,7 @@
                          class="ncl-code-entry-url">
                         <div class="field-label">
                             <span>{{ 'common:USERNAME' | i18next }}</span>
+                            <igz-more-info data-description="{{ 'functions:TOOLTIP.GIT.USERNAME' | i18next }}"></igz-more-info>
                         </div>
                         <igz-validating-input-field data-field-type="input"
                                                     data-input-name="gitUsername"


### PR DESCRIPTION
- “Function” screen › “Code” tab › “Git” code-entry type:
  - Added tooltip to “Git” option  
    ![image](https://user-images.githubusercontent.com/13918850/134813338-22d62a36-b047-48b7-8ebc-94f2e73f366d.png)
  - Changed tooltip of “URL” and “Branch” from “GitHub” to “Git”
    ![image](https://user-images.githubusercontent.com/13918850/134813350-bc017841-d9ef-4e74-a645-59fa16ed29e0.png)
    ![image](https://user-images.githubusercontent.com/13918850/134813357-591a9772-6060-4319-92da-14281774543a.png)
  - Added tooltip to “Username”
    ![image](https://user-images.githubusercontent.com/13918850/134813362-b58aad65-fc48-4a5f-8493-662f221263ef.png)

Jira ticket IG-18108