### PR TITLE
Fix [Nuclio] Unexpected confirmation on function creation

### DIFF
--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -955,8 +955,8 @@
          * @returns {boolean} `true` if the function is deploying, or `false` otherwise.
          */
         function isFunctionDeploying(aFunction) {
-            var state = lodash.get(aFunction, 'status.state');
-            return !lodash.includes(self.getSteadyStates(), state);
+            var state = lodash.get(aFunction, 'status.state', '');
+            return state !== '' && !lodash.includes(self.getSteadyStates(), state);
         }
 
         /**


### PR DESCRIPTION
- On starting to create a new function it was unexpectedly recognized as deploying then the new “another user delete this function” confirmation dialog showed.

Bug originates in PR #1281 IG-19030