### PR TITLE
IG-18847 - add N/A to External invocation URL + Tooltip

### DIFF
--- a/src/nuclio/functions/version/version-monitoring/version-monitoring.less
+++ b/src/nuclio/functions/version/version-monitoring/version-monitoring.less
@@ -30,6 +30,11 @@
                             padding: 0;
                         }
                     }
+                    .external-invocation-urls{
+                        .more-info-wrapper{
+                            height: auto;
+                        }
+                    }
                 }
 
                 &.without-collapse {

--- a/src/nuclio/functions/version/version-monitoring/version-monitoring.tpl.html
+++ b/src/nuclio/functions/version/version-monitoring/version-monitoring.tpl.html
@@ -7,7 +7,7 @@
                 <div class="monitoring-block invocation-block">
                     <div class="internal-invocation-urls">
                         <span class="monitoring-block-title">{{ 'functions:INTERNAL_INVOCATION_URLS' | i18next }}: </span>
-                        <ul class="invocation-url-list">
+                        <ul class="invocation-url-list" ng-if="!$ctrl.isFunctionDeploying()">
                             <li class="monitoring-invocation-url-wrapper" data-ng-repeat="url in $ctrl.version.status.internalInvocationUrls">
                                 <span>{{url}}</span>
                                 <div class="igz-action-panel">
@@ -17,9 +17,15 @@
                                 </div>
                             </li>
                         </ul>
+                        <p data-ng-if="!$ctrl.version.status.internalInvocationUrls.length || $ctrl.isFunctionDeploying()" data-ng-i18next="common:N_A"></p>
                     </div>
                     <div class="external-invocation-urls">
                         <span class="monitoring-block-title">{{ 'functions:EXTERNAL_INVOCATION_URLS' | i18next }}: </span>
+                        <igz-more-info
+                                data-description="{{ 'functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE' | i18next:{functionId: $ctrl.version.metadata.name} }}"
+                                data-trigger="click"
+                                data-is-html-enabled="true">
+                        </igz-more-info>
                         <ul class="invocation-url-list"
                             data-ng-if="$ctrl.version.status.externalInvocationUrls.length > 0 && !$ctrl.isFunctionDeploying()">
                             <li class="monitoring-invocation-url-wrapper" data-ng-repeat="url in $ctrl.version.status.externalInvocationUrls">
@@ -31,10 +37,7 @@
                                 </div>
                             </li>
                         </ul>
-                        <p data-ng-if="!$ctrl.version.status.externalInvocationUrls.length && !$ctrl.isFunctionDeploying()"
-                              data-ng-i18next="[html:i18next]({functionId: $ctrl.version.metadata.name})functions:TOOLTIP.TO_MAKE_FUNCTION_ACCESSIBLE">
-                        </p>
-                        <p data-ng-if="$ctrl.isFunctionDeploying()" data-ng-i18next="common:N_A"></p>
+                        <p data-ng-if="!$ctrl.version.status.externalInvocationUrls || $ctrl.version.status.externalInvocationUrls.length === 0 || $ctrl.isFunctionDeploying()" data-ng-i18next="common:N_A"></p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- “Function” screen › “Status” tab: Moved description of how to add external invocation URLs into a more-info tooltip, and made sure “N/A” is displayed for both internal and external URL lists when no such URL is available (during deploy and on error, too).
  ![image](https://user-images.githubusercontent.com/13918850/138698558-c6e8149c-7a2a-4c42-b6ed-42e5a3b614e7.png)
  ![image](https://user-images.githubusercontent.com/13918850/138698563-dd45b756-449e-417f-b7f6-a4f54077a053.png)
  ![image](https://user-images.githubusercontent.com/13918850/138698610-81b9532e-b6e2-4dc0-97a6-802886957d8d.png)

Jira ticket IG-18847