### PR TITLE
Fix [Nuclio] Target CPU: wrong style of link in tooltip

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -295,7 +295,7 @@
     "SUB_PATH": "Sub path",
     "SUBSCRIPTIONS": "Subscriptions",
     "SUCCESSFULLY_DEPLOYED": "Successfully deployed",
-    "TARGET_CPU_DESCRIPTION": "Exceeding this threshold will increase the number of replicas (default: {{default}}). Note that the percentage of utilization is based on the resource request. <a href=\"https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics\" target=\"_blank\">more info</a>",
+    "TARGET_CPU_DESCRIPTION": "Exceeding this threshold will increase the number of replicas (default: {{default}}). Note that the percentage of utilization is based on the resource request. <a class=\"link\" href=\"https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics\" target=\"_blank\">more info</a>",
     "TEMPLATE_PARAMETERS": "Template parameters",
     "TEMPLATES": "Templates",
     "THEME": "Theme",


### PR DESCRIPTION
- “Function” screen › “Configuration” tab › “Resources” pane › “Target CPU” field › Tooltip: Wrong (inconsistent with the rest of the app) styling of the link text on idle and hover.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/138690098-0caccdbb-f10e-4823-a88d-ab4ca0cbdc5b.png) ![image](https://user-images.githubusercontent.com/13918850/138690103-0ac48067-783d-4647-8c45-8ade0de2ad35.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/138690130-33691c2e-f955-48c1-95b5-67872ae90e39.png) ![image](https://user-images.githubusercontent.com/13918850/138690133-695a39cb-e10e-43e2-9dd5-6fc18bab59d6.png)

Continuing PR https://github.com/iguazio/dashboard-controls/pull/1287 IG-18410
