### PR TITLE
Impl [Clusters] move "support logs" tab to "clusters" rather then "data cluster"

### DIFF
--- a/src/igz_controls/components/navigation-tabs/navigation-tabs.service.js
+++ b/src/igz_controls/components/navigation-tabs/navigation-tabs.service.js
@@ -123,11 +123,6 @@
                     tabName: $i18next.t('common:NODES', {lng: lng}),
                     uiRoute: 'app.cluster.nodes',
                     capability: 'clusters.nodes'
-                },
-                {
-                    tabName: $i18next.t('common:SUPPORT_LOGS', {lng: lng}),
-                    uiRoute: 'app.cluster.support-logs',
-                    capability: 'clusters.collectLogs'
                 }
             ];
 
@@ -161,6 +156,12 @@
                     id: 'app',
                     uiRoute: 'app.clusters.app',
                     capability: 'clusters'
+                },
+                {
+                    tabName: $i18next.t('common:SUPPORT_LOGS', {lng: lng}),
+                    id: 'support-logs',
+                    uiRoute: 'app.clusters.support-logs',
+                    capability: 'clusters.collectLogs'
                 }
             ];
         }


### PR DESCRIPTION
- **Clusters**: move "support logs" tab to "clusters" rather then "data cluster"
  https://jira.iguazeng.com/browse/IG-20088
  Before: 
  ![image](https://user-images.githubusercontent.com/63646693/154965911-17310420-3f58-44db-b419-8f5d71616337.png)

  After:
  ![image](https://user-images.githubusercontent.com/78905712/154948621-888d8f20-6bf5-48da-8140-3f37c094f5e5.png)

