### PR TITLE
Impl [General] Rename "Project Admin" to "Project Security Admin"

### DIFF
--- a/src/igz_controls/components/multiple-checkboxes/multiple-checkboxes.component.js
+++ b/src/igz_controls/components/multiple-checkboxes/multiple-checkboxes.component.js
@@ -260,14 +260,15 @@
                     var id = lodash.defaultTo(option.id, '');
 
                     return {
-                        label: fetchOptionProperty(option, newLabelPath, LABEL_PATH_DEFAULT),
-                        value: fetchOptionProperty(option, newValuePath, VALUE_PATH_DEFAULT),
+                        checked: option.checked,
                         disabled: fetchOptionProperty(option, newDisabledPath, DISABLED_PATH_DEFAULT, false),
                         enableTooltip: fetchOptionProperty(option, TOOLTIP_ENABLED, TOOLTIP_ENABLED, false),
-                        tooltipText: fetchOptionProperty(option, TOOLTIP_TEXT, TOOLTIP_TEXT),
-                        id: generateOptionId(newBaseId, id, index),
-                        checked: option.checked,
                         filtered: option.filtered,
+                        id: generateOptionId(newBaseId, id, index),
+                        label: fetchOptionProperty(option, newLabelPath, LABEL_PATH_DEFAULT),
+                        moreInfo: option.moreInfo,
+                        tooltipText: fetchOptionProperty(option, TOOLTIP_TEXT, TOOLTIP_TEXT),
+                        value: fetchOptionProperty(option, newValuePath, VALUE_PATH_DEFAULT),
                         visibility: fetchOptionProperty(option, VISIBILITY_DEFAULT, VISIBILITY_DEFAULT, true)
                     };
                 });

--- a/src/igz_controls/components/multiple-checkboxes/multiple-checkboxes.less
+++ b/src/igz_controls/components/multiple-checkboxes/multiple-checkboxes.less
@@ -10,7 +10,16 @@
         padding: 0;
 
         .multiple-checkboxes-option {
+            display: flex;
             margin: 5px 0;
+
+            .more-info-wrapper {
+                height: auto;
+
+                .igz-icon-help-round {
+                    font-size: 14px;
+                }
+            }
         }
     }
 

--- a/src/igz_controls/components/multiple-checkboxes/multiple-checkboxes.tpl.html
+++ b/src/igz_controls/components/multiple-checkboxes/multiple-checkboxes.tpl.html
@@ -164,6 +164,10 @@
                    data-tooltip-append-to-body="true">
                 {{item.label}}
             </label>
+            <igz-more-info data-ng-if="item.moreInfo"
+                           data-description="{{item.moreInfo}}"
+                           data-default-tooltip-placement="top">
+            </igz-more-info>
         </li>
     </ul>
 


### PR DESCRIPTION
- **General**: Rename "Project Admin" to "Project Security Admin"
  Change the name of the role `Project Admin` to `Project Security Admin` and add a mark next to it with a tooltip "Note that this role provides permission to switch project's owner. it should only be used by an admin for security purposes (e.g. change a project owner when the owner is not longer exist".

  https://jira.iguazeng.com/browse/IG-20117
  ![image](https://user-images.githubusercontent.com/74406479/154984672-f7b501ee-470c-4423-94a9-d2f63709ccea.png)
