### PR TITLE
Fix [Nuclio][Function Configuration] Remove nuclio.io 'Prefix' validation from Annotations

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-annotations/version-configuration-annotations.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-annotations/version-configuration-annotations.component.js
@@ -75,9 +75,6 @@
             if (lodash.has(changes, 'version')) {
                 ctrl.annotations = lodash.chain(ctrl.version)
                     .get('metadata.annotations', {})
-                    .omitBy(function (value, key) {
-                        return lodash.startsWith(key, 'nuclio.io/');
-                    })
                     .map(function (value, key) {
                         return {
                             name: key,
@@ -165,10 +162,6 @@
          */
         function updateAnnotations() {
             var isFormValid = true;
-            var annotations = lodash.get(ctrl.version, 'metadata.annotations', {});
-            var nuclioAnnotations = lodash.pickBy(annotations, function (value, key) {
-                return lodash.startsWith(key, 'nuclio.io/');
-            });
             var newAnnotations = {};
 
             lodash.forEach(ctrl.annotations, function (annotation) {
@@ -187,8 +180,6 @@
                 component: 'annotation',
                 isDisabled: !isFormValid
             });
-
-            lodash.merge(newAnnotations, nuclioAnnotations);
 
             lodash.set(ctrl.version, 'metadata.annotations', newAnnotations);
             ctrl.onChangeCallback();


### PR DESCRIPTION
Backport PR: #1326 from development branch into iguazio-3.2 branch

Related To: [Fix [Nuclio][Function Configuration] Remove nuclio.io 'Prefix' validation from Annotations #1320](https://github.com/iguazio/dashboard-controls/pull/1320)
Jira: https://jira.iguazeng.com/browse/IG-20192


**FIX**
1. nuclio.io 'Prefix' validation was accidentally removed from "Labels" keys
2. annotation with nuclio.io key prefix is hidden from the list of annotations after function deploy
