### PR TITLE
Impl [Nuclio] Support pod tolerations for nuclio functions

### DIFF
--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -272,6 +272,7 @@
     "RESPONSE_IMAGE": "Response image",
     "REVERT_NODE_SELECTORS_TO_DEFAULTS_CONFIRM": "Are you sure you want revert the node selectors to its defaults?",
     "REVERT_TO_DEFAULTS": "Revert to defaults",
+    "RUN_ON_SPOT_NODES": "Run on Spot nodes",
     "RUNTIME": "Runtime",
     "RUNTIME_ATTRIBUTES": "Runtime Attributes",
     "SASL_PASSWORD": "SASL password",
@@ -340,6 +341,10 @@
         },
         "NEW_TEST": "New test",
         "NO_INTERNET_ACCESS": "Use local Docker images rather than pulling from remote",
+        "POD_TOLERATIONS": {
+            "ALLOW": "Allow function pods to run on spot nodes. Spot nodes might be tainted, using this option will make sure function pods tolerates those taints.",
+            "CONSTRAIN": "Constrain function pods to spot nodes using label selectors."
+        },
         "PREFIXED_NAME": "{{name}} keys are composed of an optional prefix and a name, separated by a forward slash (/) — '&lt;key prefix&gt;/&lt;key name&gt;'.",
         "REDIRECT_UNAUTHORIZED_REQUESTS": "This option should be used if the API endpoint is used by GUI. It will redirect the application to the login screen upon unauthorized request.",
         "RUN_FUNCTION": "Run function",

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
@@ -1,4 +1,4 @@
-/* eslint max-statements: ["error", 60] */
+/* eslint max-statements: ["error", 65] */
 (function () {
     'use strict';
 
@@ -90,7 +90,24 @@
             ],
             value: ValidationService.getValidationRules('k8s.qualifiedName')
         };
+        ctrl.podTolerationsOptions = [
+            {
+                id: 'allow',
+                name: 'Allow',
+                tooltip: $i18next.t('functions:TOOLTIP.POD_TOLERATIONS.ALLOW', {lng: lng})
+            },
+            {
+                id: 'constrain',
+                name: 'Constrain',
+                tooltip: $i18next.t('functions:TOOLTIP.POD_TOLERATIONS.CONSTRAIN', {lng: lng})
+            },
+            {
+                id: 'none',
+                name: 'None'
+            }
+        ];
         ctrl.revertToDefaultsBtnIsHidden = true;
+        ctrl.selectedPodTolerationOption = null;
         ctrl.windowSizeSlider = {};
 
         ctrl.$onInit = onInit;
@@ -107,6 +124,7 @@
         ctrl.memoryDropdownCallback = memoryDropdownCallback;
         ctrl.memoryInputCallback = memoryInputCallback;
         ctrl.onChangeNodeSelectorsData = onChangeNodeSelectorsData;
+        ctrl.podTolerationDropdownCallback = podTolerationDropdownCallback;
         ctrl.replicasInputCallback = replicasInputCallback;
         ctrl.sliderInputCallback = sliderInputCallback;
 
@@ -119,6 +137,7 @@
          */
         function onInit() {
             initTargetCpuSlider();
+            initPodToleration();
 
             ctrl.memoryWarningOpen = false;
 
@@ -366,6 +385,16 @@
         }
 
         /**
+         * Pod toleration dropdown callback
+         * @param {Object} tolerationOption
+         * @param {boolean} isItemChanged
+         * @param {string} field
+         */
+        function podTolerationDropdownCallback(tolerationOption, isItemChanged, field) {
+            lodash.set(ctrl.version, field, tolerationOption.id);
+        }
+
+        /**
          * Replicas data update callback
          * @param {string|number} newData
          * @param {string} field
@@ -470,7 +499,7 @@
                     key: selector.name,
                     value: selector.value
                 }
-            })
+            });
 
             ctrl.revertToDefaultsBtnIsHidden = lodash.isEqual(
                 lodash.get(ConfigService,'nuclio.defaultFunctionConfig.attributes.spec.nodeSelector', []), nodeSelectors);
@@ -579,6 +608,21 @@
                 var parsedValue = parseFloat(value);
 
                 return parsedValue > 0 ? parsedValue : null;
+            }
+        }
+
+        /**
+         * Init default parameters for pod toleration
+         */
+        function initPodToleration() {
+            var preemptionMode = lodash.get(ctrl.version, 'spec.preemptionMode');
+
+            ctrl.selectedPodTolerationOption = preemptionMode                   ?
+                lodash.find(ctrl.podTolerationsOptions, ['id', preemptionMode]) :
+                lodash.find(ctrl.podTolerationsOptions, ['id', 'none']);
+
+            if (!preemptionMode) {
+                lodash.set(ctrl.version, 'spec.preemptionMode', ctrl.selectedPodTolerationOption.id);
             }
         }
 

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.less
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.less
@@ -38,7 +38,7 @@
                     width: 35%
                 }
 
-                .gpu-number-input, .replicas-number-input {
+                .gpu-number-input, .replicas-number-input, .preemtion-mode-input {
                     width: 85%;
                 }
             }

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
@@ -2,6 +2,22 @@
     <form name="$ctrl.resourcesForm" class="resources-wrapper" novalidate>
         <div class="title">{{ 'common:RESOURCES' | i18next }}</div>
         <div class="row">
+            <div class="igz-row form-row">
+                <div class="igz-col-40 row-title">{{ 'functions:RUN_ON_SPOT_NODES' | i18next }}</div>
+
+                <div class="igz-col-20 input-wrapper"></div>
+
+                <div class="igz-col-40 input-wrapper">
+                    <div class="row-input preemtion-mode-input">
+                        <igz-default-dropdown data-values-array="$ctrl.podTolerationsOptions"
+                                              data-selected-item="$ctrl.selectedPodTolerationOption"
+                                              data-is-disabled="$ctrl.isFunctionDeploying()"
+                                              data-item-select-callback="$ctrl.podTolerationDropdownCallback(item, isItemChanged, field)"
+                                              data-item-select-field="spec.preemptionMode">
+                        </igz-default-dropdown>
+                    </div>
+                </div>
+            </div>
             <div class="igz-row form-row range-inputs-row">
                 <div class="igz-col-20 row-title">{{ 'common:MEMORY' | i18next }}
                     <igz-more-info data-trigger="click"


### PR DESCRIPTION
- **Nuclio**: Support pod tolerations for nuclio functions
  Add "Run on Spot nodes" a drop down selection from configuration tab with following selections
   - "Allow" (tooltip: Allow function pods to run on spot nodes. Spot nodes might be tainted, using this option will make sure function pods tolerates those taints)
   - "Constrain" (tooltip: Constrain function pods to spot nodes using label selectors.)
   - "None"
   
  https://jira.iguazeng.com/browse/IG-20210
  ![image](https://user-images.githubusercontent.com/74406479/156384508-7fe566ca-cbc3-4719-93bf-25fe8dd4b6cd.png)
