### PR TITLE
Fix [UI] Fixed timeout, when "Disconnection" popup should be displayed

### DIFF
--- a/src/igz_controls/services/server-status.service.js
+++ b/src/igz_controls/services/server-status.service.js
@@ -54,7 +54,7 @@
                     const dateNow = new Date();
                     const timeFromFirstFailure = (dateNow.getTime() - existingFailedResponse.date.getTime());
 
-                    if (timeFromFirstFailure >= 3000) {
+                    if (timeFromFirstFailure >= 300000) {
                         return showAlert()
                             .then(function () {
                                 location.reload();


### PR DESCRIPTION
Backport PR #1348 from development branch into iguazio-3.2 branch 
- **Error Messages**: Multiple customers: the dashboard is too sensitive for disconnections
  Jira:  https://jira.iguazeng.com/browse/IG-20334
**Fix**:
  1. “Refresh” pop up used to display when server was unreachable, Now it would be shown only after 5min, if server is still unreachable
   
