### PR TITLE
Fix [Nuclio] UI is adding entry code user and password to the displayed yaml

### DIFF
--- a/src/nuclio/functions/version/version-code/version-code.tpl.html
+++ b/src/nuclio/functions/version/version-code/version-code.tpl.html
@@ -327,7 +327,8 @@
                         <div class="field-label">
                             <span>{{ 'common:PASSWORD' | i18next }}</span>
                         </div>
-                        <igz-validating-input-field data-field-type="password"
+                        <igz-validating-input-field data-auto-complete="new-password"
+                                                    data-field-type="password"
                                                     data-input-name="gitPassword"
                                                     data-input-value="$ctrl.version.spec.build.codeEntryAttributes.password"
                                                     data-is-focused="false"


### PR DESCRIPTION
- **Nuclio**: UI is adding entry code user and password to the displayed yaml
  Jira: https://jira.iguazeng.com/browse/IG-20411
  Before:
  ![image](https://user-images.githubusercontent.com/78905712/159934031-ed3b58d9-e265-486b-aa01-1c17506d266b.png)

  After:
  ![image](https://user-images.githubusercontent.com/78905712/159933837-834bcb49-35ae-44ed-80ef-8cb922c4d08d.png)
