### PR TITLE
Fix [Nuclio] Realtime statistics load time - nuclio metrics should include the project name as a label

### DIFF
--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.component.js
@@ -35,8 +35,8 @@
 
         ctrl.functionActions = [];
         ctrl.functionNameTooltip = '';
+        ctrl.functionMetrics = FunctionsService.functionMetrics;
         ctrl.isFunctionCollapsed = true;
-        ctrl.nuclioFunctionsGpu = FunctionsService.functionMetrics.FUNCTION_GPU;
         ctrl.runtimes = {
             'golang': 'Go',
             'python:2.7': 'Python 2.7',

--- a/src/nuclio/functions/function-collapsing-row/function-collapsing-row.tpl.html
+++ b/src/nuclio/functions/function-collapsing-row/function-collapsing-row.tpl.html
@@ -83,58 +83,58 @@
             </div>
 
             <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                        data-name="nuclio_function_cpu-{{$ctrl.function.metadata.name}}"
+                                        data-name="{{$ctrl.functionMetrics.FUNCTION_CPU}}-{{$ctrl.function.metadata.name}}"
                                         data-loading-status-size="small"
                                         data-ng-class="[$ctrl.getFunctionsTableColSize('cpuCores')]">
-                <igz-size data-ng-if="!$ctrl.function.ui.error.nuclio_function_cpu && $ctrl.isFunctionCollapsed"
+                <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_CPU] && $ctrl.isFunctionCollapsed"
                           data-type="functions_cpu"
                           data-entity="$ctrl.function"
                           data-test-id="functions.item-cpu">
                 </igz-size>
-                <div data-ng-if="$ctrl.function.ui.error.nuclio_function_cpu && $ctrl.isFunctionCollapsed">
-                    {{$ctrl.function.ui.error.nuclio_function_cpu}}
+                <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_CPU] && $ctrl.isFunctionCollapsed">
+                    {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_CPU]}}
                 </div>
             </igz-element-loading-status>
 
             <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                        data-name="nuclio_function_mem-{{$ctrl.function.metadata.name}}"
+                                        data-name="{{$ctrl.functionMetrics.FUNCTION_MEMORY}}-{{$ctrl.function.metadata.name}}"
                                         data-loading-status-size="small"
                                         data-ng-class="[$ctrl.getFunctionsTableColSize('metricsSize')]">
-                <igz-size data-ng-if="!$ctrl.function.ui.error.nuclio_function_mem && $ctrl.isFunctionCollapsed"
+                <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_MEMORY] && $ctrl.isFunctionCollapsed"
                           data-type="functions_memory"
                           data-entity="$ctrl.function"
                           data-test-id="functions.item-memory">
                 </igz-size>
-                <div data-ng-if="$ctrl.function.ui.error.nuclio_function_mem && $ctrl.isFunctionCollapsed">
-                    {{$ctrl.function.ui.error.nuclio_function_mem}}
+                <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_MEMORY] && $ctrl.isFunctionCollapsed">
+                    {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_MEMORY]}}
                 </div>
             </igz-element-loading-status>
 
             <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                        data-name="{{$ctrl.nuclioFunctionsGpu}}-{{$ctrl.function.metadata.name}}"
+                                        data-name="{{$ctrl.functionMetrics.FUNCTION_GPU}}-{{$ctrl.function.metadata.name}}"
                                         data-loading-status-size="small"
                                         data-ng-class="[$ctrl.getFunctionsTableColSize('gpuCores')]">
-                <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.nuclioFunctionsGpu] && $ctrl.isFunctionCollapsed"
+                <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_GPU] && $ctrl.isFunctionCollapsed"
                           data-type="functions_gpu"
                           data-entity="$ctrl.function"
                           data-test-id="functions.item-gpu">
                 </igz-size>
-                <div data-ng-if="$ctrl.function.ui.error[$ctrl.nuclioFunctionsGpu] && $ctrl.isFunctionCollapsed">
-                    {{$ctrl.function.ui.error[$ctrl.nuclioFunctionsGpu]}}
+                <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_GPU] && $ctrl.isFunctionCollapsed">
+                    {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_GPU]}}
                 </div>
             </igz-element-loading-status>
 
             <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                        data-name="nuclio_processor_handled_events_total-{{$ctrl.function.metadata.name}}"
+                                        data-name="{{$ctrl.functionMetrics.FUNCTION_EVENTS}}-{{$ctrl.function.metadata.name}}"
                                         data-loading-status-size="small"
                                         data-ng-class="[$ctrl.getFunctionsTableColSize('metricsCount')]">
-                <igz-size data-ng-if="!$ctrl.function.ui.error.nuclio_processor_handled_events_total && $ctrl.isFunctionCollapsed"
+                <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_EVENTS] && $ctrl.isFunctionCollapsed"
                           data-type="functions_events"
                           data-entity="$ctrl.function"
                           data-test-id="functions.item-invocations">
                 </igz-size>
-                <div data-ng-if="$ctrl.function.ui.error.nuclio_processor_handled_events_total && $ctrl.isFunctionCollapsed">
-                    {{$ctrl.function.ui.error.nuclio_processor_handled_events_total}}
+                <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_EVENTS] && $ctrl.isFunctionCollapsed">
+                    {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_EVENTS]}}
                 </div>
             </igz-element-loading-status>
         </div>

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.component.js
@@ -24,7 +24,7 @@
         var ctrl = this;
         var lng = i18next.language;
 
-        ctrl.nuclioFunctionsGpu = FunctionsService.functionMetrics.FUNCTION_GPU;
+        ctrl.functionMetrics = FunctionsService.functionMetrics;
         ctrl.versionActions = [];
         ctrl.runtimes = {
             'golang': 'Go',

--- a/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.tpl.html
+++ b/src/nuclio/functions/function-collapsing-row/function-version-row/function-version-row.tpl.html
@@ -45,54 +45,54 @@
         </div>
 
         <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                    data-name="nuclio_function_cpu-{{$ctrl.function.metadata.name}}"
+                                    data-name="{{$ctrl.functionMetrics.FUNCTION_CPU}}-{{$ctrl.function.metadata.name}}"
                                     data-loading-status-size="small"
                                     data-ng-class="[$ctrl.getFunctionsTableColSize('cpuCores')]">
-            <igz-size data-ng-if="!$ctrl.function.ui.error.nuclio_function_cpu && !$ctrl.isFunctionCollapsed"
+            <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_CPU] && !$ctrl.isFunctionCollapsed"
                       data-type="functions_cpu"
                       data-entity="$ctrl.function">
             </igz-size>
-            <div data-ng-if="$ctrl.function.ui.error.nuclio_function_cpu">
-                {{$ctrl.function.ui.error.nuclio_function_cpu}}
+            <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_CPU]">
+                {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_CPU]}}
             </div>
         </igz-element-loading-status>
 
         <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                    data-name="nuclio_function_mem-{{$ctrl.function.metadata.name}}"
+                                    data-name="{{$ctrl.functionMetrics.FUNCTION_MEMORY}}-{{$ctrl.function.metadata.name}}"
                                     data-loading-status-size="small"
                                     data-ng-class="[$ctrl.getFunctionsTableColSize('metricsSize')]">
-            <igz-size data-ng-if="!$ctrl.function.ui.error.nuclio_function_mem && !$ctrl.isFunctionCollapsed"
+            <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_MEMORY] && !$ctrl.isFunctionCollapsed"
                       data-type="functions_memory"
                       data-entity="$ctrl.function">
             </igz-size>
-            <div data-ng-if="$ctrl.function.ui.error.nuclio_function_mem">
-                {{$ctrl.function.ui.error.nuclio_function_mem}}
+            <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_MEMORY]">
+                {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_MEMORY]}}
             </div>
         </igz-element-loading-status>
 
         <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                    data-name="{{$ctrl.nuclioFunctionsGpu}}-{{$ctrl.function.metadata.name}}"
+                                    data-name="{{$ctrl.functionMetrics.FUNCTION_GPU}}-{{$ctrl.function.metadata.name}}"
                                     data-loading-status-size="small"
                                     data-ng-class="[$ctrl.getFunctionsTableColSize('gpuCores')]">
-            <igz-size data-ng-if="!$ctrl.function.ui.error.kube_metrics_server_pods_gpu_utilization && !$ctrl.isFunctionCollapsed"
+            <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_GPU] && !$ctrl.isFunctionCollapsed"
                       data-type="functions_gpu"
                       data-entity="$ctrl.function">
             </igz-size>
-            <div data-ng-if="$ctrl.function.ui.error.kube_metrics_server_pods_gpu_utilization">
-                {{$ctrl.function.ui.error.kube_metrics_server_pods_gpu_utilization}}
+            <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_GPU]">
+                {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_GPU]}}
             </div>
         </igz-element-loading-status>
 
         <igz-element-loading-status class="common-table-cell element-loading-status-wrapper"
-                                    data-name="nuclio_processor_handled_events_total-{{$ctrl.function.metadata.name}}"
+                                    data-name="{{$ctrl.functionMetrics.FUNCTION_EVENTS}}-{{$ctrl.function.metadata.name}}"
                                     data-loading-status-size="small"
                                     data-ng-class="[$ctrl.getFunctionsTableColSize('metricsCount')]">
-            <igz-size data-ng-if="!$ctrl.function.ui.error.nuclio_processor_handled_events_total && !$ctrl.isFunctionCollapsed"
+            <igz-size data-ng-if="!$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_EVENTS] && !$ctrl.isFunctionCollapsed"
                       data-type="functions_events"
                       data-entity="$ctrl.function">
             </igz-size>
-            <div data-ng-if="$ctrl.function.ui.error.nuclio_processor_handled_events_total">
-                {{$ctrl.function.ui.error.nuclio_processor_handled_events_total}}
+            <div data-ng-if="$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_EVENTS]">
+                {{$ctrl.function.ui.error[$ctrl.functionMetrics.FUNCTION_EVENTS]}}
             </div>
         </igz-element-loading-status>
     </div>

--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -9,9 +9,7 @@
             checkedItem: '',
             functionMetrics: {
                 FUNCTION_CPU: 'nuclio_function_cpu',
-                FUNCTION_GPU: encodeURI(
-                    'kube_metrics_server_pods_gpu_utilization * on (pod) group_left(function_name)(nuclio_function_pod_labels)'
-                ),
+                FUNCTION_GPU: 'kube_metrics_server_pods_gpu_utilization',
                 FUNCTION_MEMORY: 'nuclio_function_mem',
                 FUNCTION_EVENTS: 'nuclio_processor_handled_events_total'
             },


### PR DESCRIPTION
- **Nuclio realtime statistics load time**: nuclio metrics should include the project name as a label
   Jira: https://jira.iguazeng.com/browse/IG-20388