### PR TITLE
Fix [Nuclio] Remove "Max length between two periods: 63" validation from secret name

### DIFF
--- a/src/igz_controls/services/validation.service.js
+++ b/src/igz_controls/services/validation.service.js
@@ -16,6 +16,7 @@
                 dns1123Subdomain: 253,
                 prefixedQualifiedName: 253,
                 qualifiedName: 63,
+                secretName: 253,
                 wildcardDns1123Subdomain: 253
             },
             function: {
@@ -328,6 +329,12 @@
                     generateRule.validCharacters('a-z A-Z 0-9 - _ .'),
                     generateRule.beginEndWith('a-z A-Z 0-9'),
                     generateRule.length({ max: lengths.k8s.qualifiedName })
+                ],
+                secretName: [
+                    generateRule.validCharacters('a-z 0-9 - .'),
+                    generateRule.beginEndWith('a-z 0-9'),
+                    generateRule.noConsecutiveCharacters('.. .- -.'),
+                    generateRule.length({ max: lengths.k8s.secretName })
                 ],
                 wildcardDns1123Subdomain: [
                     generateRule.validCharacters('a-z A-Z 0-9 - . *'),

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.component.js
@@ -31,7 +31,7 @@
                 pattern: validateUniqueness.bind(null, 'name')
             }]),
             secretKey: ValidationService.getValidationRules('k8s.configMapKey'),
-            secret: ValidationService.getValidationRules('k8s.dns1123Subdomain'),
+            secret: ValidationService.getValidationRules('k8s.secretName'),
             configmapKey: ValidationService.getValidationRules('k8s.configMapKey', [
                 {
                     name: 'uniqueness',


### PR DESCRIPTION
- **Nuclio**: Remove "Max length between two periods: 63" validation from secret name
   Jira: https://jira.iguazeng.com/browse/IG-20523

   Before:
   ![image](https://user-images.githubusercontent.com/78905712/162391285-184c58a9-3b25-4ff2-85e4-4df69baf9c44.png)

   After:
   ![image](https://user-images.githubusercontent.com/78905712/162391135-9d81465b-f7c3-47f6-8b51-5e2cccb2a855.png)
