### PR TITLE
Fix [Nuclio] Nuclio UI - show default resources (mem,cpu) when first creating function

### DIFF
--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -187,7 +187,8 @@
                         runtimeAttributes: {
                             repositories: []
                         }
-                    }
+                    },
+                    resources: $stateParams.isNewFunction ? lodash.get(ConfigService, 'nuclio.defaultFunctionPodResources', {}) : {}
                 },
                 ui: {
                     versionCode: '',


### PR DESCRIPTION
- **Nuclio**: UI - show default resources (mem,cpu) when first creating function
   Jira: https://jira.iguazeng.com/browse/IG-20659
   ![image](https://user-images.githubusercontent.com/74406479/167834503-14b34625-4685-4024-ab4d-9288a8939a06.png)