### PR TITLE
Impl [UI] Ability for IT_admin to set labels on app nodes ( vanilla K8s)

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -273,6 +273,7 @@
     "KEYS": "Keys",
     "LABEL": "Label",
     "LAST_DAY": "Last day",
+    "LABELS": "Labels",
     "LAST_MODIFIED": "Last modified",
     "LAST_MONTH": "Last month",
     "LAST_NAME": "Last name",

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -159,7 +159,6 @@
     "INVOCATION_URL": "Invocation URL",
     "ITEM_KEY": "Item key",
     "JVM_OPTIONS": "JVM options",
-    "LABELS": "Labels",
     "LARGE": "Large",
     "LOGGER_DESTINATION": "Logger destination",
     "LOGGER_LEVEL": "Logger level",

--- a/src/igz_controls/less/table.less
+++ b/src/igz_controls/less/table.less
@@ -76,6 +76,10 @@
         &.centered {
             justify-content: center;
         }
+
+        &.overflow-visible {
+            overflow: visible;
+        }
     }
 
     //

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-labels/version-configuration-labels.tpl.html
@@ -1,6 +1,6 @@
 <div class="ncl-version-configuration-labels">
     <div class="title">
-        <span>{{ 'functions:LABELS' | i18next }}</span>
+        <span>{{ 'common:LABELS' | i18next }}</span>
         <igz-more-info
                 data-description="{{$ctrl.tooltip}}"
                 data-trigger="click"


### PR DESCRIPTION
- **Clusters**: Ability for IT_admin to set labels on app nodes
   Jira: https://jira.iguazeng.com/browse/IG-20635
   Backported to 3.4 from development: #1383 
   ![image](https://user-images.githubusercontent.com/74406479/171866104-32f03364-764e-4b40-89f4-2a0b6e36fb95.png)
   
   ![image](https://user-images.githubusercontent.com/74406479/171866149-0a9b890f-28dc-489a-9261-dfd0ce09b964.png)
