### PR TITLE
Impl [Clusters] key/value field is missing validation

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -328,6 +328,7 @@
     "NO_EVENTS": "No events",
     "NO_TASKS": "No {{- currentTab}} tasks",
     "NOT_READY": "Not ready",
+    "NOT_START_WITH_FORBIDDEN_WORDS_K8S": "Must not start with 'kubernetes.io', 'k8s.io'",
     "NODE": "Node",
     "NODES": "Nodes",
     "NONE": "None",

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -180,7 +180,6 @@
     "NO_LOGS_HAVE_BEEN_FOUND": "No logs have been found...",
     "NODE_SELECTORS": "Node selector",
     "NORMAL": "Normal",
-    "NOT_START_WITH_FORBIDDEN_WORDS_ANNOTATION": "Must not start with 'kubernetes.io', 'k8s.io'",
     "NOT_START_WITH_FORBIDDEN_WORDS_LABEL": "Must not start with 'kubernetes.io', 'k8s.io' or 'nuclio.io'",
     "NOT_YET_DEPLOYED": "Not yet deployed",
     "OAUTH2": "OAuth2",

--- a/src/igz_controls/services/validation.service.js
+++ b/src/igz_controls/services/validation.service.js
@@ -374,7 +374,7 @@
                         {
                             name: 'prefixNotStart',
                             label: '[' + $i18next.t('functions:PREFIX', {lng: lng}) + '] ' +
-                                $i18next.t('functions:NOT_START_WITH_FORBIDDEN_WORDS_ANNOTATION', {lng: lng}),
+                                $i18next.t('common:NOT_START_WITH_FORBIDDEN_WORDS_K8S', {lng: lng}),
                             pattern: /^(?!kubernetes\.io\/)(?!k8s\.io\/)/
                         })
                 },
@@ -439,6 +439,15 @@
                     value: [generateRule.length({ max: lengths.service.persistentVolumeClaims.value })]
                 },
                 hiveMetastorePath: [generateRule.endNotWith('/')]
+            },
+            clusters: {
+                label: commonRules.prefixedQualifiedName.concat(
+                    {
+                        name: 'prefixNotStart',
+                        label: '[' + $i18next.t('functions:PREFIX', {lng: lng}) + '] ' +
+                            $i18next.t('common:NOT_START_WITH_FORBIDDEN_WORDS_K8S', {lng: lng}),
+                        pattern: /^(?!kubernetes\.io\/)(?!k8s\.io\/)/
+                    })
             },
             container: {
                 name: [


### PR DESCRIPTION
- **Clusters**: key/value field is missing validation in "Edit labels" for app cluster nodes dialog
   Backported to `3.5.1` from #1400 
   Jira: https://jira.iguazeng.com/browse/IG-20847

   Before:
   
![image](https://user-images.githubusercontent.com/78905712/177777360-10e2be11-a8ec-4c85-8325-1d5f2175470e.png)

   After:
![image](https://user-images.githubusercontent.com/78905712/177779151-3023a6d1-d438-4d02-9ecb-250c1637474f.png)
   