### PR TITLE
Fix [Function Configuration] "Image name" bubble info long text overflow

### DIFF
--- a/src/igz_controls/components/more-info/more-info.less
+++ b/src/igz_controls/components/more-info/more-info.less
@@ -70,6 +70,7 @@
         font-weight: 400;
         white-space: pre-line;
         line-height: normal;
+        overflow-wrap: break-word;
 
         &::before {
             position: absolute;


### PR DESCRIPTION
- **Function** nuclio "Image name" bubble info long text overflow
   Backported to `3.5.1` from #1402 
   Jira: https://jira.iguazeng.com/browse/IG-20989
   Before:
   ![image](https://user-images.githubusercontent.com/78905712/180774649-bf085c05-8f8d-4c2c-a59d-7f865b9a7b3d.png)

   After:
   ![image](https://user-images.githubusercontent.com/78905712/180774629-a69654d1-3024-4a6d-93c9-85160ca52d93.png)
