### PR TITLE
Fix [Function Configuration] "Image name" bubble info long text overflow

### DIFF
--- a/src/igz_controls/components/more-info/more-info.less
+++ b/src/igz_controls/components/more-info/more-info.less
@@ -70,6 +70,7 @@
         font-weight: 400;
         white-space: pre-line;
         line-height: normal;
+        overflow-wrap: break-word;
 
         &::before {
             position: absolute;


### PR DESCRIPTION
https://jira.iguazeng.com/browse/IG-20989

Before:
![image](https://user-images.githubusercontent.com/78905712/180774751-1ca5b0bd-2abf-472b-abf5-5de0806cd589.png)

After:
![image](https://user-images.githubusercontent.com/78905712/180774735-f43ee4b2-91a5-4a91-8a0d-d90bc304aaa8.png)
