### PR TITLE
Fix [Nuclio] Error pop-up is missing error message.

### DIFF
--- a/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
+++ b/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
@@ -265,7 +265,7 @@
                         ctrl.closeDialog({ newApiGateway: apiGateway});
                     })
                     .catch(function (error) {
-                        var errorMessage = lodash.get(error, 'data.errors[0].detail', error.statusText);
+                        var errorMessage = lodash.get(error, 'data.error', lodash.get(error, 'data.errors[0].detail', error.statusText));
 
                         DialogsService.alert(errorMessage);
                     });


### PR DESCRIPTION
- **UI**: api-gateway saved when primary assigned function is deleted during api-gw creation
   Jira: [IG-21094](https://jira.iguazeng.com/browse/IG-21094)
   Related to : Jira: https://jira.iguazeng.com/browse/IG-17643 and #1370 

   Before:
   ![image](https://user-images.githubusercontent.com/78905712/165962046-67937ae3-4c2b-471b-8af2-83ecfd54a3f3.png)

   After:
   ![image](https://user-images.githubusercontent.com/78905712/165962072-f8cdc6e9-fb1e-4b7f-a6ef-e8ed2c81c764.png)
