### PR TITLE
Fix [Nuclio] Python templates do not show source code in UI 3.5

### DIFF
--- a/src/nuclio/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/functions/version/version-code/version-code.component.js
@@ -428,6 +428,14 @@
                     visible: true
                 },
                 {
+                    id: 'python',
+                    ext: 'py',
+                    name: 'Python',
+                    language: 'python',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
                     id: 'python:3.6',
                     ext: 'py',
                     name: 'Python 3.6',


### PR DESCRIPTION
**UI**: [Nuclio] Python templates do not show source code in UI
   Jira: [IG-20969](https://jira.iguazeng.com/browse/IG-20969)

   Before:
   ![image-2022-07-19-11-08-58-305](https://user-images.githubusercontent.com/105363136/205639203-adf3e19f-956f-4652-9fb1-6761fff33e38.png)

   After:
   ![Screenshot from 2022-12-05 14-33-11](https://user-images.githubusercontent.com/105363136/205639226-1aaadb84-f0c9-4dc1-ac6d-d405e234d6c7.png)

