### PR TITLE
Fix [UI] Show new auto scale metrics only when enabled `3.5.x`

### DIFF
--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.component.js
@@ -62,7 +62,7 @@
                 }
             }
         ];
-
+        ctrl.customMetricsAreEnabled = lodash.get(ConfigService, 'nuclio.autoScaleMetrics.customMetricsEnabled', false);
         ctrl.defaultFunctionConfig = lodash.get(ConfigService, 'nuclio.defaultFunctionConfig.attributes', {});
 
         ctrl.dropdownOptions = [
@@ -701,24 +701,26 @@
          * Initializes Target CPU slider.
          */
         function initTargetCpuSlider() {
-            ctrl.targetCpuValueUnit = '';
-            ctrl.targetCpuSliderConfig = {
-                value: lodash.get(ctrl.defaultFunctionConfig, 'spec.resources.targetCPU', 75),
-                valueLabel: 'disabled',
-                pow: 0,
-                unitLabel: '%',
-                labelHelpIcon: false,
-                options: {
-                    disabled: true,
-                    floor: 1,
-                    id: 'targetCPU',
-                    ceil: 100,
-                    step: 1,
-                    showSelectionBar: true
-                }
-            };
+            if (!ctrl.customMetricsAreEnabled) {
+                ctrl.targetCpuValueUnit = '';
+                ctrl.targetCpuSliderConfig = {
+                    value: lodash.get(ctrl.defaultFunctionConfig, 'spec.resources.targetCPU', 75),
+                    valueLabel: 'disabled',
+                    pow: 0,
+                    unitLabel: '%',
+                    labelHelpIcon: false,
+                    options: {
+                        disabled: true,
+                        floor: 1,
+                        id: 'targetCPU',
+                        ceil: 100,
+                        step: 1,
+                        showSelectionBar: true
+                    }
+                };
 
-            updateTargetCpuSlider();
+                updateTargetCpuSlider();
+            }
         }
 
         /**

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-resources/version-configuration-resources.tpl.html
@@ -260,7 +260,8 @@
                 </div>
             </div>
 
-            <div class="igz-row form-row range-inputs-row slider-block">
+            <div class="igz-row form-row range-inputs-row slider-block"
+                 data-ng-if="!$ctrl.customMetricsAreEnabled">
                 <div class="igz-col-25 row-title no-margin target-cpu-title">
                     <span>{{ 'common:TARGET_CPU' | i18next }}</span>
                     <igz-more-info
@@ -320,7 +321,8 @@
             </div>
         </div>
     </form>
-    <ncl-auto-scale-metrics-table data-is-function-deploying="$ctrl.isFunctionDeploying()"
+    <ncl-auto-scale-metrics-table data-ng-if="$ctrl.customMetricsAreEnabled"
+                                  data-is-function-deploying="$ctrl.isFunctionDeploying()"
                                   data-version="$ctrl.version">
     </ncl-auto-scale-metrics-table>
 </div>


### PR DESCRIPTION
- **UI**: Show new auto scale metrics only when enabled
   Backported to `3.5.x` from #1456 
   Jira: https://jira.iguazeng.com/browse/IG-21569