### PR TITLE
Fix [Clusters] error reason is not displayed when updating app node label fails `3.5.x`

### DIFF
--- a/src/igz_controls/components/toast-status-panel/toast-status-panel.less
+++ b/src/igz_controls/components/toast-status-panel/toast-status-panel.less
@@ -52,8 +52,12 @@
             }
         }
 
-        .panel-status-msg {
-            margin-left: 8px;
+        .msg-scrollable-container {
+            max-height: 300px;
+
+            .panel-status-msg {
+                margin: 0 8px;
+            }
         }
     }
 }

--- a/src/igz_controls/components/toast-status-panel/toast-status-panel.tpl.html
+++ b/src/igz_controls/components/toast-status-panel/toast-status-panel.tpl.html
@@ -6,6 +6,8 @@
     </div>
     <div class="panel-status">
         <span class="panel-status-icon"></span>
-        <span class="panel-status-msg">{{$ctrl.getStateMessage($ctrl.panelState)}}</span>
+        <div class="igz-scrollable-container msg-scrollable-container" data-ng-scrollbars>
+            <div class="panel-status-msg">{{$ctrl.getStateMessage($ctrl.panelState)}}</div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
- **UI**: error reason is not displayed when updating app node label fails
   Backported from #1473 to `3.5.x`
   Jira: https://jira.iguazeng.com/browse/IG-21777

   After:
   ![Screenshot from 2023-05-05 17-15-28](https://github.com/iguazio/dashboard-controls/assets/109525572/d155e682-2007-4053-90d2-3611f4b5fe2e)
