### PR TITLE
Fix [Nuclio] Response body from nuclio function is not always being shown in case of error

### DIFF
--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
@@ -865,7 +865,7 @@ such restriction.
          * @param {*} value - the object or a JSON-serialized string to format.
          * @returns {*} JSON-serialized string representation of `value` formatted with newlines and indentation.
          *      In case of an error in JSON conversion or if `value` is not a string nor an object, returns `value`
-         *      as-is.
+         *      as a string.
          */
         function formatJson(value) {
             try {
@@ -883,11 +883,11 @@ such restriction.
             }
 
             /**
-             * Returns `value`.
-             * @returns {*} `value` as-is.
+             * Returns `value` as a string.
+             * @returns {*} `value` as a string.
              */
             function returnValue() {
-                return value;
+                return value.toString();
             }
         }
 


### PR DESCRIPTION
- **Nuclio** Response body from nuclio function is not always being shown in case of error
   Jira: https://jira.iguazeng.com/browse/IG-21923