### PR TITLE
Fix [Nuclio] Response body from nuclio function is not always being shown in case of error `3.5.x`

### DIFF
--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
@@ -849,7 +849,7 @@
          * @param {*} value - the object or a JSON-serialized string to format.
          * @returns {*} JSON-serialized string representation of `value` formatted with newlines and indentation.
          *      In case of an error in JSON conversion or if `value` is not a string nor an object, returns `value`
-         *      as-is.
+         *      as a string.
          */
         function formatJson(value) {
             try {
@@ -867,11 +867,11 @@
             }
 
             /**
-             * Returns `value`.
-             * @returns {*} `value` as-is.
+             * Returns `value` as a string.
+             * @returns {*} `value` as a string.
              */
             function returnValue() {
-                return value;
+                return value.toString();
             }
         }
 


### PR DESCRIPTION
- **Nuclio** Response body from nuclio function is not always being shown in case of error
   Backported to `3.5.x` from #1480 
   Jira: https://jira.iguazeng.com/browse/IG-21923