### PR TITLE
Fix [Nuclio] Remove python 3.6, add message about soon deprecation for3.7 and 3.8 `3.5.x`

### DIFF
--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
@@ -370,19 +370,15 @@
                     visible: true
                 },
                 {
-                    id: 'python:3.6',
-                    name: 'Python 3.6 ' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}),
-                    nameTemplate: 'Python 3.6 ' + '<b>' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}) + '</b>',
-                    visible: true
-                },
-                {
                     id: 'python:3.7',
-                    name: 'Python 3.7',
+                    name: 'Python 3.7 ' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}),
+                    nameTemplate: 'Python 3.7 ' + '<b>' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}) + '</b>',
                     visible: true
                 },
                 {
                     id: 'python:3.8',
-                    name: 'Python 3.8',
+                    name: 'Python 3.8 ' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}),
+                    nameTemplate: 'Python 3.8 ' + '<b>' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}) + '</b>',
                     visible: true
                 },
                 {


### PR DESCRIPTION
- **Nuclio**: Remove python 3.6, add message about soon deprecation for3.7 and 3.8
   Backported to `3.5.x` from #1490 
   Jira: https://jira.iguazeng.com/browse/IG-22188

   After:
   ![image](https://github.com/iguazio/dashboard-controls/assets/78905712/5bce8fab-8338-42cb-9226-2e180e13e581)
