### PR TITLE
Fix [Nuclio] remove python3.6 from "Start from scratch" `3.5.4.2`

### DIFF
--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
@@ -203,21 +203,15 @@
                     visible: true
                 },
                 {
-                    id: 'python:3.6',
-                    name: 'Python 3.6',
-                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
-                    visible: true
-                },
-                {
                     id: 'python:3.7',
-                    name: 'Python 3.7',
-                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    name: 'Python 3.7 ' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}),
+                    nameTemplate: 'Python 3.7 ' + '<b>' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}) + '</b>',
                     visible: true
                 },
                 {
                     id: 'python:3.8',
-                    name: 'Python 3.8',
-                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    name: 'Python 3.8 ' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}),
+                    nameTemplate: 'Python 3.8 ' + '<b>' + $i18next.t('functions:DEPRECATED_SOON_LABEL', {lng: lng}) + '</b>',
                     visible: true
                 },
                 {


### PR DESCRIPTION
- **Nuclio**: Remove python3.6 from "Start from scratch" `3.5.4.2`
   Jira: https://jira.iguazeng.com/browse/IG-22344
   
   After:
   ![image](https://github.com/iguazio/dashboard-controls/assets/78905712/9711196d-e6aa-4e22-8a1a-e9db0bfd14cf)
