### PR TITLE
Fix [UI] Bump "minimatch" version `3.5.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-eslint": "^6.0.0",
     "gulp-file-transform-cache": ">=1.0.6",
     "gulp-htmlmin": "^5.0.1",
-    "gulp-if": "^1.2.5",
+    "gulp-if": "^3.0.0",
     "gulp-imagemin": "^7.1.0",
     "gulp-less": "4.0.1",
     "gulp-less-import": "^1.0.0",


### PR DESCRIPTION
- **UI**: Bump "minimatch" version
   Backported to `3.5.x` from #1526 
   Jira: https://jira.iguazeng.com/browse/NUC-145