### PR TITLE
Fix [User group] Member update not accepting email in "copy/paste" `3.5.x`

### DIFF
--- a/src/igz_controls/services/validation.service.js
+++ b/src/igz_controls/services/validation.service.js
@@ -570,7 +570,7 @@
                         generateRule.length({ max: lengths.identity.user.username })
                     ],
                     usernameMembers: [
-                        generateRule.validCharacters('a-z A-Z 0-9 - _'),
+                        generateRule.validCharacters('a-z A-Z 0-9 - _ @ .'),
                         generateRule.length({ max: lengths.identity.user.username })
                     ],
                     email: commonRules.email.concat(generateRule.length({ max: lengths.identity.user.email })),


### PR DESCRIPTION
- **User group**: Member update not accepting email in "copy/paste"
   Backported to `3.5.x` from #1539 
   Jira: https://iguazio.atlassian.net/browse/IG-22637