### PR TITLE
Fix [Identity] incorrect filter description in 'Groups' tab

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -370,6 +370,7 @@
     "PLACEHOLDER": {
         "ADD_DESCRIPTION": "Click to add a description…",
         "AUTO_COMPLETE_DEFAULT": "Start typing to get suggestion list...",
+        "BY_NAME": "By name...",
         "CHIPS_INPUT_DEFAULT": "Start typing, or press space to select a value…",
         "COMMA_DELIMITED_LIST_OF_NUMBERS": "1,3-6,9-10,14,...",
         "COMMA_DELIMITED_LIST_OF_STRINGS": "value1,value2,value3,...",


### PR DESCRIPTION
- **Identity**: incorrect filter description in 'Groups' tab
   Jira: https://iguazio.atlassian.net/browse/IG-22597