### PR TITLE
Fix [Nuclio] Function status isn't updated on reload action `3.5.x`

### DIFF
--- a/src/nuclio/functions/version/version.component.js
+++ b/src/nuclio/functions/version/version.component.js
@@ -388,6 +388,7 @@
                     setVersion(aFunction);
                     setImageNamePrefixTemplate();
                     setIngressHost();
+                    updateStatusTabIndicator();
                 })
                 .catch(function (error) {
                     if (!GeneralDataService.isDisconnectionError(error.status)) {


### PR DESCRIPTION
- **Nuclio**: Function status isn't updated on reload action
   Backported to `3.5.x` from #1544 
   Jira: https://iguazio.atlassian.net/browse/NUC-152