### PR TITLE
Fix [Nuclio] ADD_ENVIRONMENT_VARIABLE is shown `3.5.x`

### DIFF
--- a/dist/i18n/en/functions.json
+++ b/dist/i18n/en/functions.json
@@ -58,7 +58,6 @@
     "CREATE_FUNCTION_EVENT": "Create function event",
     "CREATE_NEW_API_GATEWAY": "Create a new API Gateway",
     "CREATE_NEW_BINDING": "Create a new binding",
-    "CREATE_NEW_ENVIRONMENT_VARIABLE": "Create a new environment variable",
     "CREATE_NEW_HEADER": "Create a new header",
     "CREATE_NEW_HOST": "Create a new host",
     "CREATE_NEW_RUNTIME_ATTRIBUTE": "Create a new runtime attribute",

--- a/src/nuclio/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.tpl.html
+++ b/src/nuclio/functions/version/version-configuration/tabs/version-configuration-environment-variables/version-configuration-environment-variables.tpl.html
@@ -26,7 +26,7 @@
              data-ng-class="{ 'disabled': $ctrl.isFunctionDeploying() }"
              data-ng-click="$ctrl.addNewVariable($event)">
             <span class="igz-icon-add-round"></span>
-            {{ 'functions:ADD_NEW_ENVIRONMENT_VARIABLE' | i18next }}
+            {{ 'common:ADD_ENVIRONMENT_VARIABLE' | i18next }}
         </div>
     </form>
 </div>


### PR DESCRIPTION
- **Nuclio**: ADD_ENVIRONMENT_VARIABLE is shown
   Backported to `3.5.x` from #1549 
   Jira: https://iguazio.atlassian.net/browse/IG-22746