### PR TITLE
Fix [Data -> Browse] - columns are not resized, only first letter of object is being shown

### DIFF
--- a/src/igz_controls/less/igz-grid.less
+++ b/src/igz_controls/less/igz-grid.less
@@ -154,7 +154,7 @@
 }
 
 &.igz-col-33 {
-    width: 100% / 3;
+    width: calc(100% / 3);
 }
 
 &.igz-col-34 {


### PR DESCRIPTION
- **Data => Browse**:  Columns are not resized, only first letter of object is being shown
   Jira: https://iguazio.atlassian.net/browse/IG-22787