### PR TITLE
Fix [UI] the dashboard adds ldaps:// prefix by default despite ldaps being unsupported

### DIFF
--- a/src/igz_controls/services/validation.service.js
+++ b/src/igz_controls/services/validation.service.js
@@ -602,8 +602,8 @@ such restriction.
                 address: [
                     {
                         name: 'begin',
-                        label: $i18next.t('common:BEGIN_WITH', { lng: lng }) + ': ldaps://, ldap://',
-                        pattern: /^ldaps?:\/\//
+                        label: $i18next.t('common:BEGIN_WITH', { lng: lng }) + ': ldap://',
+                        pattern: /^ldap?:\/\//
                     }
                 ]
             },


### PR DESCRIPTION
- **UI**: The dashboard adds ldaps:// prefix by default despite ldaps being unsupported
   Implements: https://github.com/iguazio/dashboard/pull/4774
   Jira: https://iguazio.atlassian.net/browse/IG-22906