### PR TITLE
Fix [UI] Can't create more than 1 gateway per function `1.13.x`

### DIFF
--- a/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
+++ b/src/nuclio/api-gateways/new-api-gateway-wizard/new-api-gateway-wizard.component.js
@@ -305,15 +305,9 @@ such restriction.
             suggestionsList = lodash.chain(functionsList)
                 .filter(function (aFunction) {
                     var functionName = lodash.get(aFunction, 'metadata.name');
-                    var functionApiGateways = lodash.chain(aFunction)
-                        .get('status.apiGateways', [])      // get the function's list of related API GWs
-                        .without(ctrl.apiGateway.spec.name) // remove current API GW name from list
-                        .value();
                     var functionAlreadyUsedInThisApiGateway = lodash.includes(upstreamsFunctionNames, functionName);
-                    var functionAlreadyUsedInAnotherApiGateway = !lodash.isEmpty(functionApiGateways);
 
                     return !functionAlreadyUsedInThisApiGateway &&
-                        !functionAlreadyUsedInAnotherApiGateway &&
                         (lodash.isEmpty(lodash.trim(newData)) || lodash.includes(functionName, newData));
                 })
                 .map(function (aFunction) {


### PR DESCRIPTION
- **UI**: Can't create more than 1 gateway per function
   Backported to `1.13.x` from https://github.com/iguazio/dashboard-controls/pull/1574
   Jira: https://iguazio.atlassian.net/browse/NUC-237