### PR TITLE
Nuclio UI - Support disabling default http trigger creation for a specific function`1.14.x` (Revert to 3.6.0 Revert)

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -107,6 +107,7 @@
     "DO_NOT_SHOW_AGAIN": "Do not show again",
     "DOCS": "Docs",
     "DONE": "Done",
+    "DO_NOT_CREATE_HTTP_TRIGGER_BY_DEFAULT": "Do not create http trigger by default",
     "DONT_LEAVE": "Don't leave",
     "DONT_REFRESH": "Don't refresh",
     "DONT_SAVE": "Don't save",

--- a/src/i18n/en/functions.json
+++ b/src/i18n/en/functions.json
@@ -325,6 +325,7 @@
         "DEPLOY_IN_PROGRESS": "Deploy is already in-progress.",
         "DISABLE_CACHE": "Build the function's Docker image from scratch without reusing any previously built Docker image layers.",
         "DISABLED_FUNCTION": "Only running and scaled-to-zero functions can be tested.",
+        "DO_NOT_CREATE_HTTP_TRIGGER_BY_DEFAULT": "When not checked, an http trigger will be created for the function by default.",
         "GIT": {
             "BRANCH": "The Git repository branch from which to download the function code.",
             "BRANCH_TAG_REFERENCE_DISABLED": "Exactly one of Branch, Tag, and Reference fields must be filled. When one is filled, the others are disabled.",

--- a/src/nuclio/functions/version/version-triggers/version-triggers.component.js
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.component.js
@@ -83,6 +83,7 @@ such restriction.
         ctrl.editTriggerCallback = editTriggerCallback;
         ctrl.handleAction = handleAction;
         ctrl.isCreateNewTriggerEnabled = isCreateNewTriggerEnabled;
+        ctrl.isHttpTriggerCheckboxShown = isHttpTriggerCheckboxShown;
         ctrl.isHttpTriggerMsgShown = isHttpTriggerMsgShown;
 
         //
@@ -253,14 +254,21 @@ such restriction.
             });
         }
 
+         /**
+         * Tests whether the `Do not create http trigger by default` checkbox is shown
+         * @returns {boolean}
+         */
+        function isHttpTriggerCheckboxShown() {
+            return !lodash.get(ConfigService, 'nuclio.disableDefaultHttpTrigger', false) &&
+                   !lodash.some(ctrl.version.spec.triggers, ['kind', 'http']);
+        }
+
         /**
          * Tests whether the `HTTP trigger message` is shown
          * @returns {boolean} `true` in case "HTTP trigger message" is shown, or `false` otherwise.
          */
         function isHttpTriggerMsgShown() {
-            const disableDefaultHttpTrigger = lodash.get(ConfigService, 'nuclio.disableDefaultHttpTrigger', false);
-
-            return !disableDefaultHttpTrigger && !lodash.some(ctrl.version.spec.triggers, ['kind', 'http']);
+            return isHttpTriggerCheckboxShown() && !ctrl.version.spec.disableDefaultHTTPTrigger;
         }
 
         //

--- a/src/nuclio/functions/version/version-triggers/version-triggers.less
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.less
@@ -28,6 +28,10 @@
         }
     }
 
+    .http-trigger-checkbox {
+        display: flex;
+    }
+
     .item-row .item-name, .item-row .item-class, .item-row .item-info {
         padding-left: 0;
     }

--- a/src/nuclio/functions/version/version-triggers/version-triggers.tpl.html
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.tpl.html
@@ -3,6 +3,22 @@
         <div class="content-message-pane"
              data-ng-if="$ctrl.isHttpTriggerMsgShown()" data-ng-i18next="[html]functions:HTTP_TRIGGER_MSG">
         </div>
+        <div class="http-trigger-checkbox" data-ng-if="$ctrl.isHttpTriggerCheckboxShown()">
+            <input type="checkbox"
+                   class="small"
+                   id="disable-default-http-trigger"
+                   name="disableDefaultHTTPTrigger"
+                   data-ng-model="$ctrl.version.spec.disableDefaultHTTPTrigger"
+                   data-ng-disabled="$ctrl.isFunctionDeploying()"
+                   >
+            <label for="disable-default-http-trigger"
+                   class="checkbox-inline">{{ 'common:DO_NOT_CREATE_HTTP_TRIGGER_BY_DEFAULT' | i18next }}</label>
+            <igz-more-info
+                    data-description="{{ 'functions:TOOLTIP.DO_NOT_CREATE_HTTP_TRIGGER_BY_DEFAULT' | i18next }}"
+                    data-trigger="click"
+                    data-default-tooltip-placement="right">
+            </igz-more-info>
+        </div>
         <div class="common-table-header header-row">
             <div class="common-table-cell header-name">
                 {{ 'common:NAME' | i18next }}


### PR DESCRIPTION
- **Nuclio**: Support disabling default http trigger creation for a specific function1.14.x
   Jira: https://iguazio.atlassian.net/browse/NUC-325