### PR TITLE
Fix [Nuclio]  The Node selector status isn't updated even after pressing the refresh button `nuc_1.13.x`

### DIFF
--- a/src/nuclio/functions/version/version-monitoring/version-monitoring.component.js
+++ b/src/nuclio/functions/version/version-monitoring/version-monitoring.component.js
@@ -47,6 +47,7 @@ such restriction.
         };
 
         ctrl.$onInit = onInit;
+        ctrl.$onChanges = onChanges;
 
         ctrl.checkIsErrorState = checkIsErrorState;
         ctrl.onRowCollapse = onRowCollapse;
@@ -62,6 +63,16 @@ such restriction.
             ctrl.isFunctionDeploying = lodash.partial(FunctionsService.isFunctionDeploying, ctrl.version);
 
             initEnrichedNodeSelectors();
+        }
+
+        /**
+         * On changes hook method
+         * @param {Object} changes
+         */
+        function onChanges(changes) {
+            if (lodash.has(changes, 'version')) {
+                initEnrichedNodeSelectors();
+            }
         }
 
         //


### PR DESCRIPTION
- **Nuclio**: The Node selector status isn't updated even after pressing the refresh button `1.13.x`
   Backport to `1.13.x` from #1623 
   Jira: https://iguazio.atlassian.net/browse/IG-23328