### PR TITLE
Impl [UI] Add Python 3.12 to Nuclio runtime dropdown `3.6.x`

### DIFF
--- a/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-scratch/function-from-scratch.component.js
@@ -237,6 +237,12 @@ such restriction.
                     visible: true
                 },
                 {
+                    id: 'python:3.12',
+                    name: 'Python 3.12',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
                     id: 'dotnetcore',
                     name: '.NET Core ' + $i18next.t('functions:TECH_PREVIEW_LABEL', { lng: lng }),
                     sourceCode: 'dXNpbmcgU3lzdGVtOw0KdXNpbmcgTnVjbGlvLlNkazsNCg0KcHVibGljIGNsYXNzIG1haW4NCnsNCiAgICBwdWJ' +

--- a/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
+++ b/src/nuclio/common/screens/create-function/function-from-template/function-from-template.component.js
@@ -404,6 +404,12 @@ such restriction.
                     visible: true
                 },
                 {
+                    id: 'python:3.12',
+                    name: 'Python 3.12',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
                     id: 'dotnetcore',
                     name: '.NET Core ' + $i18next.t('functions:TECH_PREVIEW_LABEL', {lng: lng}),
                     visible: true

--- a/src/nuclio/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/functions/version/version-code/version-code.component.js
@@ -225,7 +225,8 @@ such restriction.
         function onChanges(changes) {
             if (angular.isDefined(changes.version)) {
                 ctrl.runtimeArray = getRuntimes();
-                ctrl.selectedRuntime = lodash.find(ctrl.runtimeArray, ['id', ctrl.version.spec.runtime]);
+                ctrl.selectedRuntime = lodash.defaultTo(lodash.find(ctrl.runtimeArray, ['id', ctrl.version.spec.runtime]),
+                                                        lodash.find(ctrl.runtimeArray, ['id', 'python']));
                 ctrl.editorLanguage = ctrl.selectedRuntime.language;
 
                 var sourceCode = lodash.get(ctrl.version, 'spec.build.functionSourceCode', '');
@@ -492,6 +493,12 @@ such restriction.
                 {
                     id: 'python:3.11',
                     name: 'Python 3.11',
+                    sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
+                    visible: true
+                },
+                {
+                    id: 'python:3.12',
+                    name: 'Python 3.12',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true
                 },


### PR DESCRIPTION
- **UI**: Add Python 3.12 to Nuclio runtime dropdown
   Backported to `1.13.x` from #1630 
   Jira: https://iguazio.atlassian.net/browse/NUC-382