### PR TITLE
Fix [Nuclio] function syntax is not highlighted for python 3.11/3.12

### DIFF
--- a/src/nuclio/functions/version/version-code/version-code.component.js
+++ b/src/nuclio/functions/version/version-code/version-code.component.js
@@ -500,19 +500,25 @@ such restriction.
                 },
                 {
                     id: 'python:3.10',
+                    ext: 'py',
                     name: 'Python 3.10',
+                    language: 'python',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true
                 },
                 {
                     id: 'python:3.11',
+                    ext: 'py',
                     name: 'Python 3.11',
+                    language: 'python',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true
                 },
                 {
                     id: 'python:3.12',
+                    ext: 'py',
                     name: 'Python 3.12',
+                    language: 'python',
                     sourceCode: 'ZGVmIGhhbmRsZXIoY29udGV4dCwgZXZlbnQpOg0KICAgIHJldHVybiAiIg==', // source code in base64
                     visible: true
                 },


### PR DESCRIPTION
- **Nuclio**: function syntax is not highlighted for python 3.11/3.12
   Jira: https://iguazio.atlassian.net/browse/NUC-526