### PR TITLE
Fix [UI] Invocations # in nuclio isn't show the right number `3.7.x` `1.14.x` (#1672)

### DIFF
--- a/src/nuclio/functions/functions.component.js
+++ b/src/nuclio/functions/functions.component.js
@@ -718,8 +718,9 @@ such restriction.
             var projectName = '{project_name="' + ctrl.project.metadata.name + '"}';
             var gpuUtilizationMetric = ' * on (pod) group_left(function_name)(nuclio_function_pod_labels{project_name="' +
                 ctrl.project.metadata.name + '"})';
+            var invocationMetricQuery = 'increase(' + ctrl.functionEventsMetric + functionEventsProjectName + '[24h])';
             var args = {
-                metric: ctrl.functionEventsMetric + functionEventsProjectName,
+                metric: invocationMetricQuery,
                 from: from,
                 until: until,
                 interval: '5m'


### PR DESCRIPTION
- **UI**: Invocations # in nuclio isn't show the right number
   Backported to `3.7.x` from https://github.com/iguazio/dashboard-controls/pull/1672
   Jira: https://iguazio.atlassian.net/browse/IG-24321