### PR TITLE
Fix Prototype Pollution via parse() in NodeJS flatted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6802,12 +6802,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/gulp-eslint/node_modules/flatted": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-            "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-            "license": "ISC"
-        },
         "node_modules/gulp-eslint/node_modules/globals": {
             "version": "12.4.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
         "karma-chrome-launcher": "^3.1.0",
         "karma-jasmine": "^3.1.1"
     },
+    "overrides": {
+        "flatted": "^3.4.2"
+    },
     "autoupdate": {
         "source": "git",
         "target": "https://github.com/iguazio/dashboard-controls.git",


### PR DESCRIPTION
Jira: [IG-25122](https://iguazio.atlassian.net/browse/IG-25122)

**Cause**
[GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh) affects flatted < 3.4.2. In your tree, gulp-eslint → eslint@6 → file-entry-cache@5 → flat-cache@2.0.1 still declares flatted: ^2.0.0, which pulled flatted@2.0.2 into the lockfile as node_modules/gulp-eslint/node_modules/flatted. That kept Dependabot/GitHub seeing a vulnerable path even though the hoisted install was often already using 3.4.2, which also produced the invalid: flatted@3.4.2 warning from npm ls.

**Fix**
overrides in package.json so every consumer (including flat-cache@2) resolves to flatted@^3.4.2, which includes the fix (parse uses numeric indexing, e.g. input[+value], so __proto__ no longer walks the array prototype chain).

package-lock.json – removed the obsolete node_modules/gulp-eslint/node_modules/flatted block for 2.0.2 so the lockfile no longer records a vulnerable install path.

flat-cache@2 only needs flatted’s parse / stringify; 3.4.x is compatible for that usage.

**Checks**
npm ci completes cleanly.
npm ls flatted exits 0 (no invalid override).
CVE PoC: parsed.x === Array.prototype is false; [].polluted stays undefined.

[IG-25122]: https://iguazio.atlassian.net/browse/IG-25122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ