### PR TITLE
[FIX] lodash vulnerable to Code Injection via '_.template' imports key names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
                 "jquery": "^3.7.1",
                 "jquery-ui": "1.13.2",
                 "js-base64": "^2.4.8",
-                "lodash": "^4.17.21",
+                "lodash": "^4.18.0",
                 "merge2": "^0.3.6",
                 "moment": "^2.24.0",
                 "monaco-editor": "^0.11.1",
@@ -11027,12 +11027,6 @@
             "peerDependencies": {
                 "angular": ">=1.3.12"
             }
-        },
-        "node_modules/restangular/node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "license": "MIT"
         },
         "node_modules/restore-cursor": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "jquery": "^3.7.1",
         "jquery-ui": "1.13.2",
         "js-base64": "^2.4.8",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "merge2": "^0.3.6",
         "moment": "^2.24.0",
         "monaco-editor": "^0.11.1",
@@ -75,6 +75,9 @@
         "karma": "^6.3.1",
         "karma-chrome-launcher": "^3.1.0",
         "karma-jasmine": "^3.1.1"
+    },
+    "overrides": {
+        "lodash": "^4.18.0"
     },
     "autoupdate": {
         "source": "git",


### PR DESCRIPTION
Jira: https://iguazio.atlassian.net/browse/IG-25143

**Cause**
[GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) / CVE-2026-4800 is fixed in lodash ≥ 4.18.0. Your app already resolved top-level lodash to 4.18.1, but the lockfile still had restangular → node_modules/restangular/node_modules/lodash@4.17.23, which Dependabot can still treat as vulnerable.

**Change**
Direct dependency — lodash updated from ^4.17.21 to ^4.18.0 so installs always allow the patched line.

overrides — "lodash": "^4.18.0" so every dependency (including restangular’s ~4.17.0) resolves to 4.18.x and the nested 4.17.23 copy is dropped from the lockfile.

package-lock.json — refreshed so only lodash@4.18.1 appears under node_modules/lodash; the restangular nested lodash entry is gone.

npm ci completes successfully and npm ls lodash shows a single 4.18.1 everywhere (including under restangular).


```
package.json
Lines 57-57
        "lodash": "^4.18.0",

package.json
Lines 79-81
    "overrides": {
        "lodash": "^4.18.0"
    },
   ```
Note: The tree still has the legacy npm package lodash.template@3.x (used by old gulp tooling). That is not the same as lodash’s _.template and is not what this CVE patches. If you still use a flatted override from an earlier fix, merge it into the same "overrides" object as lodash instead of replacing it.