### PR TITLE
[FIX] Make RabbitMQ exchange name required only when topics is filled

### DIFF
--- a/src/nuclio/common/components/edit-item/edit-item.component.js
+++ b/src/nuclio/common/components/edit-item/edit-item.component.js
@@ -1175,7 +1175,6 @@ such restriction.
                 var intervalInputIsFilled = !lodash.isEmpty(ctrl.editItemForm.item_interval.$viewValue);
                 var scheduleInputIsFilled = !lodash.isEmpty(ctrl.editItemForm.item_schedule.$viewValue);
                 var bothFilled = intervalInputIsFilled && scheduleInputIsFilled;
-
                 scheduleField.allowEmpty = intervalInputIsFilled;
                 lodash.assign(scheduleField, {
                     moreInfoIconType: bothFilled ? 'warn' : 'info',
@@ -1188,6 +1187,7 @@ such restriction.
             } else if (ctrl.item.kind === 'rabbit-mq') {
                 var queueName = lodash.find(ctrl.selectedClass.fields, {name: 'queueName'});
                 var topics = lodash.find(ctrl.selectedClass.fields, {name: 'topics'});
+                var exchangeName = lodash.find(ctrl.selectedClass.fields, {name: 'exchangeName'});
                 var queueNameIsFilled = !lodash.isEmpty(ctrl.editItemForm.item_queueName.$viewValue);
                 var topicsIsFilled = !lodash.isEmpty(ctrl.editItemForm.item_topics.$viewValue);
 
@@ -1196,10 +1196,17 @@ such restriction.
                 // if one of them is filled, the other is allowed to be empty
                 queueName.allowEmpty = topicsIsFilled;
                 topics.allowEmpty = queueNameIsFilled;
+                // Exchange Name is only relevant when Topics is filled
+                exchangeName.allowEmpty = !topicsIsFilled;
+
+                var exchangeNameIsFilled = !lodash.isEmpty(lodash.get(ctrl.item, 'attributes.exchangeName'));
 
                 // update validity: if empty is not allowed and value is currently empty - mark invalid, otherwise valid
                 ctrl.editItemForm.item_queueName.$setValidity('text', queueName.allowEmpty || queueNameIsFilled);
                 ctrl.editItemForm.item_topics.$setValidity('text', topics.allowEmpty || topicsIsFilled);
+                if (ctrl.editItemForm.item_exchangeName) {
+                    ctrl.editItemForm.item_exchangeName.$setValidity('text', exchangeName.allowEmpty || exchangeNameIsFilled);
+                }
             } else if (ctrl.item.kind === 'kafka-cluster') {
                 var isSaslEnabled = lodash.get(ctrl.item, 'attributes.sasl.enable');
 

--- a/src/nuclio/functions/functions.service.js
+++ b/src/nuclio/functions/functions.service.js
@@ -392,7 +392,7 @@ such restriction.
                                 type: 'input',
                                 fieldType: 'input',
                                 path: 'attributes.exchangeName',
-                                allowEmpty: false
+                                allowEmpty: true
                             },
                             {
                                 name: 'queueName',

--- a/src/nuclio/functions/version/version-triggers/version-triggers.component.js
+++ b/src/nuclio/functions/version/version-triggers/version-triggers.component.js
@@ -390,6 +390,10 @@ such restriction.
             }
 
             if (angular.isDefined(triggerItem.attributes)) {
+                if (selectedItem.kind === 'rabbit-mq' && lodash.isEmpty(triggerItem.attributes.topics)) {
+                    delete triggerItem.attributes.exchangeName;
+                }
+
                 triggerItem.attributes = lodash.omitBy(triggerItem.attributes, function (attribute) {
                     return !lodash.isNumber(attribute) && lodash.isEmpty(attribute) && !lodash.isBoolean(attribute);
                 });


### PR DESCRIPTION
## 📝 Description
- Made RabbitMQ trigger's **Exchange Name** field conditionally required - it is now mandatory only when **Topics** is filled, and optional otherwise.

---

## 🛠️ Changes Made
- **`edit-item.component.js`** — Added `exchangeName` validation logic to the `rabbit-mq` block in `validateValues()`:
  - `exchangeName.allowEmpty = !topicsIsFilled` — required only when Topics has a value
  - Added `$setValidity('text', ...)` call for `item_exchangeName` form control
- **`version-triggers.component.js`** — Replaced `lodash.find(ctrl.classList, ...)` with `angular.copy(lodash.find(...))` when assigning `selectedClass` to a trigger, so each trigger gets its own independent copy of the fields definition
- **`version-triggers.component.js`** — Added cleanup before saving: `exchangeName` is removed from the payload when `topics` is empty
- **`functions.service.js`** — Changed `exchangeName.allowEmpty` initial value from `false` to `true` (dynamically controlled by `validateValues`)

---

## ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

Working Items: https://ecliptos.atlassian.net/browse/NUC-794