### PR TITLE
[Fix] Change order of invocation URL list

### DIFF
--- a/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
+++ b/src/nuclio/functions/version/version-code/function-event-pane/function-event-pane.component.js
@@ -920,7 +920,7 @@ such restriction.
                 })
                 .value();
 
-            return external.concat(internal);
+            return internal.concat(external);
         }
 
         /**


### PR DESCRIPTION
## 📝 Description
The invocation URL dropdown is populated by `generateInvocationUrlsList()`, which previously returned `external.concat(internal)` — putting external URLs first. The default should be the internal URL

---

## 🛠️ Changes Made
- **`function-event-pane.component.js`** — Swapped concat order in `generateInvocationUrlsList()` from `external.concat(internal)` to `internal.concat(external)`, so the in-cluster DNS address (`<name>.<namespace>.svc.cluster.local:8080`) is the default selection.

External URLs remain available in the dropdown for explicit user selection.

---

## 🔗 References
- Related ticket: https://ecliptos.atlassian.net/browse/NUC-874

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

---

## 🔍 Additional Notes
The nuclio backend fallback (when no `X-Nuclio-Invoke-Url` header is sent) already picks `InternalInvocationURLs[0]` — this PR aligns the UI default with that behavior.